### PR TITLE
Nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,335 @@
+name: MODFLOW 6 PRT intel nightly build
+on:
+  schedule:
+    - cron: '0 2 * * *' # run at 2 AM UTC
+  workflow_dispatch:
+env:
+  FC: ifort
+  LABEL: prtdev
+jobs:
+  build:
+    name: Build binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            artifact_name: linux
+          - os: macos-12
+            artifact_name: mac
+          - os: windows-2022
+            artifact_name: win64
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+
+      - name: Checkout modflow6
+        uses: actions/checkout@v3
+        with:
+          repository: aprovost-usgs/modflow6
+          path: modflow6
+          ref: PRT
+
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: modflow6/environment.yml
+          cache-environment: true
+          cache-downloads: true
+
+      - name: Setup Intel Fortran
+        uses: modflowpy/install-intelfortran-action@v1
+
+      - name: Fix Micromamba path (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # https://github.com/modflowpy/install-intelfortran-action#conda-scripts
+          $mamba_bin = "C:\Users\runneradmin\micromamba-root\envs\modflow6\Scripts"
+          echo $mamba_bin | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Update version
+        run: python modflow6/distribution/update_version.py -v 6.5.0-$LABEL
+
+      - name: Build binaries
+        working-directory: modflow6
+        run: |
+          meson setup builddir -Ddebug=false --prefix=$(pwd) --libdir=bin
+          meson install -C builddir
+          meson test --verbose --no-rebuild -C builddir
+
+      - name: Move code.json
+        run: cp modflow6/code.json modflow6/bin/code.json
+
+      - name: Upload binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: bin-${{ runner.os }}
+          path: modflow6/bin
+
+  docs:
+    name: Build documentation
+    needs: build
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+
+      - name: Checkout modflow6
+        uses: actions/checkout@v3
+        with:
+          repository: aprovost-usgs/modflow6
+          path: modflow6
+          ref: PRT
+
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: modflow6/environment.yml
+          cache-environment: true
+          cache-downloads: true
+
+      - name: Checkout usgslatex
+        uses: actions/checkout@v3
+        with:
+          repository: MODFLOW-USGS/usgslatex
+          path: usgslatex
+
+      - name: Install TeX Live
+        run: |
+          sudo apt-get update
+          sudo apt install texlive-latex-extra \
+            texlive-science \
+            texlive-font-utils \
+            texlive-fonts-recommended \
+            texlive-fonts-extra \
+            dos2unix
+
+      - name: Install USGS LaTeX style files and Univers font
+        working-directory: usgslatex/usgsLaTeX
+        run: sudo ./install.sh --all-users
+
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: bin-${{ runner.os }}
+          path: modflow6/bin
+
+      - name: Checkout modflow6-examples
+        uses: actions/checkout@v3
+        with:
+          repository: MODFLOW-USGS/modflow6-examples
+          path: modflow6-examples
+
+      - name: Cache modflow6 examples
+        id: cache-examples
+        uses: actions/cache@v3
+        with:
+          path: modflow6-examples/examples
+          key: modflow6-examples-${{ hashFiles('modflow6-examples/scripts/**') }}
+
+      - name: Install extra Python packages
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6-examples/etc
+        run: pip install -r requirements.pip.txt
+
+      - name: Build example models
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6-examples/etc
+        run: python ci_build_files.py
+
+      - name: Update version
+        run: python modflow6/distribution/update_version.py -v 6.5.0-$LABEL
+
+      - name: Build docs
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # example path below is hard-coded into modflow6/distribution/build_docs.py
+          # once that's fixed, this can be removed
+          mkdir -p modflow6-examples/examples/ex-gwf-twri01
+          
+          # execute permission may not have survived upload/download-artifact actions
+          chmod +x modflow6/bin/mf6
+          chmod +x modflow6/bin/mf5to6
+          chmod +x modflow6/bin/zbud6
+          
+          # build the docs
+          python modflow6/distribution/build_docs.py -d -b modflow6/bin -o docs
+
+      - name: Upload mf6io docs
+        uses: actions/upload-artifact@v3
+        with:
+          name: mf6io
+          path: docs/mf6io.pdf
+      
+      - name: Upload release notes
+        uses: actions/upload-artifact@v3
+        with:
+          name: ReleaseNotes
+          path: docs/ReleaseNotes.pdf
+
+  dist:
+    name: Build distributions
+    needs: docs
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-22.04
+            artifact_name: linux
+          - os: macos-12
+            artifact_name: mac
+          - os: windows-2022
+            artifact_name: win64
+    defaults:
+      run:
+        shell: bash -l {0}
+    steps:
+
+      - name: Checkout modflow6
+        uses: actions/checkout@v3
+        with:
+          repository: aprovost-usgs/modflow6
+          path: modflow6
+          ref: PRT
+
+      - name: Setup Micromamba
+        uses: mamba-org/setup-micromamba@v1
+        with:
+          environment-file: modflow6/environment.yml
+          cache-environment: true
+          cache-downloads: true
+
+      - name: Setup Intel Fortran
+        uses: modflowpy/install-intelfortran-action@v1
+
+      - name: Download binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: bin-${{ runner.os }}
+          path: ${{ matrix.artifact_name }}/bin
+
+      - name: Update FloPy classes
+        working-directory: modflow6/autotest
+        run: python update_flopy.py
+
+      - name: Checkout modflow6-examples
+        uses: actions/checkout@v3
+        with:
+          repository: MODFLOW-USGS/modflow6-examples
+          path: modflow6-examples
+
+      - name: Cache modflow6 examples
+        id: cache-examples
+        uses: actions/cache@v3
+        with:
+          path: modflow6-examples/examples
+          key: modflow6-examples-${{ hashFiles('modflow6-examples/scripts/**') }}
+
+      - name: Install extra Python packages
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6-examples/etc
+        run: pip install -r requirements.pip.txt
+
+      - name: Build example models
+        if: steps.cache-examples.outputs.cache-hit != 'true'
+        working-directory: modflow6-examples/etc
+        run: python ci_build_files.py
+
+      - name: Build distribution
+        run: |
+          # modflow6/distribution/build_dist.py expects the examples repo to exist,
+          # but it's not needed for nightly builds, below can be removed when fixed
+          mkdir -p modflow6-examples
+          
+          # build the dist
+          python modflow6/distribution/build_dist.py -d -o ${{ matrix.artifact_name }}
+
+      - name: Zip distribution
+        if: runner.os != 'Windows'
+        run: zip -j -r ${{ matrix.artifact_name }}.zip ${{ matrix.artifact_name }} -x '*.DS_Store'
+
+      - name: Zip distribution (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: 7z a -tzip ${{ matrix.artifact_name }}.zip ${{ github.workspace }}\${{ matrix.artifact_name }}\bin\* -xr'!libmf6.lib'
+
+      - name: Upload distribution
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_name }}.zip
+
+      - name: Upload mf6io docs
+        if: runner.os == 'Linux'
+        uses: actions/upload-artifact@v3
+        with:
+          name: mf6io
+          path: ${{ matrix.artifact_name }}/doc/mf6io.pdf
+
+  release:
+    name: Create release
+    needs: dist
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    if:
+      github.event_name == 'push' || github.event_name == 'schedule'
+    steps:
+
+      - name: Delete Older Releases
+        uses: dev-drprasad/delete-older-releases@v0.2.1
+        with:
+          keep_latest: 30
+          delete_tags: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: nightly
+
+      - name: List files in the artifact directory
+        run: ls -l nightly
+
+      - name: Get time
+        uses: josStorer/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYYMMDD
+
+      - name: Show time
+        env:
+          TIME: "${{ steps.current-time.outputs.time }}"
+          F_TIME: "${{ steps.current-time.outputs.formattedTime }}"
+        run: echo $TIME $F_TIME
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.current-time.outputs.formattedTime }}
+          name: ${{ steps.current-time.outputs.formattedTime }} nightly build
+          body: "MODFLOW 6 PRT nightly development build, compiled with Intel Fortran."
+          draft: false
+          allowUpdates: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # remove all but zip and pdf files
+      - name: Prune release assets
+        run: find nightly -type f ! -name '*.zip' ! -name '*.pdf' -delete
+
+      - name: Upload release assets
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: nightly/**
+          tag: ${{ steps.current-time.outputs.formattedTime }}
+          overwrite: true
+          file_glob: true

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: If you use this software, please cite the software itself.
 type: software
 title: MODFLOW 6 Modular Hydrologic Model
-version: 6.4.1
-date-released: '2022-12-09'
+version: 6.5.0-prt
+date-released: '2023-06-03'
 doi: 10.5066/F76Q1VQV
 abstract: MODFLOW 6 is an object-oriented program and framework developed to provide
   a platform for supporting multiple models and multiple types of models within the

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 This is the development repository for the USGS MODFLOW 6 Hydrologic Model. The  official USGS distribution is available at [USGS Release Page](https://water.usgs.gov/ogw/modflow/MODFLOW.html).
 
-### Version 6.5.0 Release Candidate
+### Version 6.5.0-prt
 
 [![GitHub release](https://img.shields.io/github/release/MODFLOW-USGS/modflow6.svg)](https://github.com/MODFLOW-USGS/modflow6/releases/latest)
 [![MODFLOW 6 continuous integration](https://github.com/MODFLOW-USGS/modflow6/actions/workflows/ci.yml/badge.svg)](https://github.com/MODFLOW-USGS/modflow6/actions/workflows/ci.yml)

--- a/autotest/test_cli.py
+++ b/autotest/test_cli.py
@@ -10,14 +10,15 @@ def test_cli_version():
         subprocess.check_output([str(bin_path / "mf6"), "-v"]).decode().split()
     )
     assert output.startswith("mf6:")
-    assert output.lower().count("release") == 1
-    # assert output.lower().count("candidate") <= 1
-
-    print(output)
 
     version = (
-        output.lower().rpartition(":")[2].rpartition("release")[0].strip()
+        output.lower().rpartition(":")[2].rpartition(" ")[0].strip()
     )
     v_split = version.split(".")
     assert len(v_split) == 3
-    assert all(s.isdigit() for s in v_split)
+    assert all(s.isdigit() for s in v_split[:2])
+    if "-" in v_split[2]:
+        spl = v_split[2].split("-")
+        assert spl[0].isdigit()
+    else:
+        assert v_split[2].isdigit()

--- a/code.json
+++ b/code.json
@@ -1,6 +1,6 @@
 [
     {
-        "status": "Release Candidate",
+        "status": "Preliminary",
         "languages": [
             "Fortran2008"
         ],
@@ -18,9 +18,9 @@
             "email": "langevin@usgs.gov"
         },
         "laborHours": -1,
-        "version": "6.5.0",
+        "version": "6.5.0-prt",
         "date": {
-            "metadataLastUpdated": "2022-12-09"
+            "metadataLastUpdated": "2023-06-03"
         },
         "organization": "U.S. Geological Survey",
         "permissions": {

--- a/distribution/update_version.py
+++ b/distribution/update_version.py
@@ -13,18 +13,16 @@ This script is used to update several files in the modflow6 repository, includin
   ../code.json
   ../src/Utilities/version.f90
 
-Information in these files include version number (major.minor.patch), build date, whether or not
-the release is a release candidate or an actual release, whether the source code should be compiled
-in develop mode or in release mode, and the approval status.
+Information in these files include version number major.minor.patch[-label], build timestamp,
+whether or not the release is a prerelease candidate or an official distribution, whether the
+source code should be compiled in develop mode or in release mode, and other version metadata.
 
-The version number is read in from ../../version.txt, which contains major, minor, and patch version
-numbers.  These numbers will be propagated through the source code, latex files, markdown files,
-etc.  The version numbers can be overridden using the command line argument --version major.minor.macro.
+The version number is read from ../version.txt, which contains major, minor, and patch version
+numbers, and an optional label. Version numbers are substituted into source code, latex files,
+markdown files, etc.  The version number can be overridden using argument --version, short -v.
 
-Develop mode is set to 0 if the distribution is approved.
-
-Once this script is run, these updated files will be used in compilation, latex documents, and
-other parts of the repo to mark the overall status.
+Develop mode is set to 0 if the distribution is approved with --approved, short -a, otherwise,
+it is set to 1.
 
 """
 import argparse
@@ -67,26 +65,30 @@ class Version(NamedTuple):
     major: int = 0
     minor: int = 0
     patch: int = 0
+    label: Optional[str] = None
 
     def __repr__(self):
-        return f"{self.major}.{self.minor}.{self.patch}"
+        s = f"{self.major}.{self.minor}.{self.patch}"
+        if self.label is not None:
+            s += f"-{self.label}"
+        return s
 
     @classmethod
     def from_string(cls, version: str) -> "Version":
         t = version.split(".")
-
+        assert len(t) > 2
         vmajor = int(t[0])
         vminor = int(t[1])
-        vpatch = int(t[2])
-
-        return cls(major=vmajor, minor=vminor, patch=vpatch)
+        tt = t[2].rpartition("-")
+        vpatch = int(tt[0])
+        vlabel = tt[2] if len(tt) > 2 else None
+        return cls(major=vmajor, minor=vminor, patch=vpatch, label=vlabel)
 
     @classmethod
     def from_file(cls, path: PathLike) -> "Version":
         path = Path(path).expanduser().absolute()
         lines = [line.rstrip("\n") for line in open(Path(path), "r")]
-
-        vmajor = vminor = vpatch = None
+        vmajor = vminor = vpatch = vlabel = None
         for line in lines:
             t = line.split()
             if "major =" in line:
@@ -95,18 +97,15 @@ class Version(NamedTuple):
                 vminor = int(t[2])
             elif "micro =" in line:
                 vpatch = int(t[2])
+            elif "label =" in line:
+                vlabel = t[2].replace("'", "")
 
-        msg = "version string must follow semantic version format: major.minor.patch"
-        assert vmajor is not None, f"Missing major number, {msg}"
-        assert vminor is not None, f"Missing minor number, {msg}"
-        assert vpatch is not None, f"Missing patch number, {msg}"
-
-        return cls(major=vmajor, minor=vminor, patch=vpatch)
-
-
-class ReleaseType(Enum):
-    CANDIDATE = "Release Candidate"
-    APPROVED = "Release"
+        msg = "version string must follow semantic version format, with optional label: major.minor.patch-[label]"
+        missing = lambda v: f"Missing {v} number, {msg}"
+        assert vmajor is not None, missing("major")
+        assert vminor is not None, missing("minor")
+        assert vpatch is not None, missing("patch")
+        return cls(major=vmajor, minor=vminor, patch=vpatch, label=vlabel)
 
 
 
@@ -166,18 +165,19 @@ resulting from the authorized or unauthorized use of the software.
 """
 
 
-def get_disclaimer(release_type: ReleaseType, formatted: bool = False) -> str:
-    approved = _approved_fmtdisclaimer if formatted else _approved_disclaimer
-    preliminary = _preliminary_fmtdisclaimer if formatted else _preliminary_disclaimer
-    return approved if release_type == ReleaseType.APPROVED else preliminary
+def get_disclaimer(approved: bool = False, formatted: bool = False) -> str:
+    if approved:
+        return _approved_fmtdisclaimer if formatted else _approved_disclaimer
+    else:
+        return _preliminary_fmtdisclaimer if formatted else _preliminary_disclaimer
 
 
-def log_update(path, release_type: ReleaseType, version: Version):
-    print(f"Updated {path} with version {version}" + (f" {release_type.value}" if release_type != ReleaseType.APPROVED else ""))
+def log_update(path, version: Version):
+    print(f"Updated {path} with version {version}")
 
 
 def update_version_txt_and_py(
-    release_type: ReleaseType, timestamp: datetime, version: Version
+    version: Version, timestamp: datetime, approved: bool = False
 ):
     with open(version_file_path, "w") as f:
         f.write(
@@ -189,38 +189,32 @@ def update_version_txt_and_py(
         f.write(f"major = {version.major}\n")
         f.write(f"minor = {version.minor}\n")
         f.write(f"micro = {version.patch}\n")
-        f.write("__version__ = '{:d}.{:d}.{:d}'.format(major, minor, micro)\n")
+        f.write(f"label = '{version.label}'\n")
+        f.write("__version__ = '{:d}.{:d}.{:d}{}'.format(major, minor, micro, label)\n")
         f.close()
-    log_update(version_file_path, release_type, version)
-
+    log_update(version_file_path, version)
     py_path = project_root_path / "doc" / version_file_path.name.replace(".txt", ".py")
     shutil.copyfile(version_file_path, py_path)
-    log_update(py_path, release_type, version)
+    log_update(py_path, version)
 
 
-def update_meson_build(release_type: ReleaseType, timestamp: datetime, version: Version):
+def update_meson_build(version: Version, timestamp: datetime):
     path = project_root_path / "meson.build"
     lines = open(path, "r").read().splitlines()
     with open(path, "w") as f:
         for line in lines:
             if "version:" in line and "meson_version:" not in line:
-                line = f"  version: '{version.major}.{version.minor}.{version.patch}',"
+                line = f"  version: '{version.major}.{version.minor}.{version.patch}{('-' + version.label) if version.label else ''}',"
             f.write(f"{line}\n")
-
-    log_update(path, release_type, version)
+    log_update(path, version)
 
 
 def update_version_tex(
-    release_type: ReleaseType, timestamp: datetime, version: Version
+    version: Version, timestamp: datetime
 ):
     path = project_root_path / "doc" / "version.tex"
-
-    version_str = str(version)
-    if release_type != ReleaseType.APPROVED:
-        version_str += "rc"
-
     with open(path, "w") as f:
-        line = "\\newcommand{\\modflowversion}{mf" + f"{version_str}" + "}"
+        line = "\\newcommand{\\modflowversion}{mf" + f"{str(version)}" + "}"
         f.write(f"{line}\n")
         line = (
             "\\newcommand{\\modflowdate}{" + f"{timestamp.strftime('%B %d, %Y')}" + "}"
@@ -231,17 +225,19 @@ def update_version_tex(
             + "{Version \\modflowversion---\\modflowdate}"
         )
         f.write(f"{line}\n")
-
-    log_update(path, release_type, version)
+    log_update(path, version)
 
 
 def update_version_f90(
-    release_type: ReleaseType, timestamp: datetime, version: Optional[Version]
+    version: Optional[Version], timestamp: datetime, approved: bool = False
 ):
     path = project_root_path / "src" / "Utilities" / "version.f90"
     lines = open(path, "r").read().splitlines()
     with open(path, "w") as f:
         skip = False
+        version_spl = str(version).rpartition("-")
+        version_num = version_spl[0]
+        version_label = version_spl[2] if len(version_spl) > 1 else ""
         for line in lines:
             # skip all of the disclaimer text
             if skip:
@@ -251,52 +247,47 @@ def update_version_f90(
             elif ":: IDEVELOPMODE =" in line:
                 line = (
                     "  integer(I4B), parameter :: "
-                    + f"IDEVELOPMODE = {1 if release_type == ReleaseType.CANDIDATE else 0}"
+                    + f"IDEVELOPMODE = {0 if approved else 1}"
                 )
             elif ":: VERSIONNUMBER =" in line:
-                line = line.rpartition("::")[0] + f":: VERSIONNUMBER = '{version}'"
+                line = line.rpartition("::")[0] + f":: VERSIONNUMBER = '{version_num}'"
             elif ":: VERSIONTAG =" in line:
                 fmat_tstmp = timestamp.strftime("%m/%d/%Y")
-                line = line.rpartition("::")[0] + f":: VERSIONTAG = ' {release_type.value} {fmat_tstmp}'"
+                line = line.rpartition("::")[0] + f":: VERSIONTAG = '-{version_label} {fmat_tstmp}'"
             elif ":: FMTDISCLAIMER =" in line:
-                line = get_disclaimer(release_type, formatted=True)
+                line = get_disclaimer(approved, formatted=True)
                 skip = True
             f.write(f"{line}\n")
-
-    log_update(path, release_type, version)
+    log_update(path, version)
 
 
 def update_readme_and_disclaimer(
-    release_type: ReleaseType, timestamp: datetime, version: Version
+    version: Version, timestamp: datetime, approved: bool = False
 ):
-    disclaimer = get_disclaimer(release_type, formatted=False)
+    disclaimer = get_disclaimer(approved, formatted=False)
     readme_path = str(project_root_path / "README.md")
     readme_lines = open(readme_path, "r").read().splitlines()
     with open(readme_path, "w") as f:
         for line in readme_lines:
             if "## Version " in line:
                 version_line = f"### Version {version}"
-                if release_type != ReleaseType.APPROVED:
-                    version_line += f" {release_type.value}"
                 f.write(f"{version_line}\n")
             elif "Disclaimer" in line:
                 f.write(f"{disclaimer}\n")
                 break
             else:
                 f.write(f"{line}\n")
-    log_update(readme_path, release_type, version)
+    log_update(readme_path, version)
 
     disclaimer_path = project_root_path / "DISCLAIMER.md"
     with open(disclaimer_path, "w") as f:
         f.write(disclaimer)
-    log_update(disclaimer_path, release_type, version)
+    log_update(disclaimer_path, version)
 
 
-def update_citation_cff(release_type: ReleaseType, timestamp: datetime, version: Version):
+def update_citation_cff(version: Version, timestamp: datetime):
     path = project_root_path / "CITATION.cff"
     citation = yaml.safe_load(path.read_text())
-
-    # update version and date-released
     citation["version"] = str(version)
     citation["date-released"] = timestamp.strftime("%Y-%m-%d")
 
@@ -308,28 +299,28 @@ def update_citation_cff(release_type: ReleaseType, timestamp: datetime, version:
             default_flow_style=False,
             sort_keys=False,
         )
-    log_update(path, release_type, version)
+    log_update(path, version)
 
 
-def update_codejson(release_type: ReleaseType, timestamp: datetime, version: Version):
+def update_codejson(version: Version, timestamp: datetime, approved: bool = False):
     path = project_root_path / "code.json"
     with open(path, "r") as f:
         data = json.load(f, object_pairs_hook=OrderedDict)
 
     data[0]["date"]["metadataLastUpdated"] = timestamp.strftime("%Y-%m-%d")
     data[0]["version"] = str(version)
-    data[0]["status"] = release_type.value
+    data[0]["status"] = "Release" if approved else "Preliminary"
     with open(path, "w") as f:
         json.dump(data, f, indent=4)
         f.write("\n")
 
-    log_update(path, release_type, version)
+    log_update(path, version)
 
 
 def update_version(
-    release_type: ReleaseType = ReleaseType.CANDIDATE,
-    timestamp: datetime = datetime.now(),
     version: Version = None,
+    timestamp: datetime = datetime.now(),
+    approved: bool = False
 ):
     """
     Update version information stored in version.txt in the project root,
@@ -351,13 +342,13 @@ def update_version(
         )
 
         with lock:
-            update_version_txt_and_py(release_type, timestamp, version)
-            update_meson_build(release_type, timestamp, version)
-            update_version_tex(release_type, timestamp, version)
-            update_version_f90(release_type, timestamp, version)
-            update_readme_and_disclaimer(release_type, timestamp, version)
-            update_citation_cff(release_type, timestamp, version)
-            update_codejson(release_type, timestamp, version)
+            update_version_txt_and_py(version, timestamp, approved)
+            update_meson_build(version, timestamp)
+            update_version_tex(version, timestamp)
+            update_version_f90(version, timestamp, approved)
+            update_readme_and_disclaimer(version, timestamp, approved)
+            update_citation_cff(version, timestamp)
+            update_codejson(version, timestamp, approved)
     finally:
         lock_path.unlink(missing_ok=True)
 
@@ -368,11 +359,13 @@ _current_version = Version.from_file(version_file_path)
 
 @pytest.mark.skip(reason="reverts repo files on cleanup, tread carefully")
 @pytest.mark.parametrize(
-    "release_type", [ReleaseType.CANDIDATE, ReleaseType.APPROVED]
+    "approved", [False, True]
 )
 @pytest.mark.parametrize(
     "version",
-    [None, Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch)],
+    [None,
+     Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch),
+     Version(major=_initial_version.major, minor=_initial_version.minor, patch=_initial_version.patch, label="rc")],
 )
 def test_update_version(tmp_path, release_type, version):
     m_times = [get_modified_time(file) for file in touched_file_paths]
@@ -391,11 +384,18 @@ def test_update_version(tmp_path, release_type, version):
             assert updated.major == _initial_version.major
             assert updated.minor == _initial_version.minor
             assert updated.patch == _initial_version.patch
+            if version.label is not None:
+                assert updated.label == version.label
         else:
             # version should not have changed
             assert updated.major == _current_version.major
             assert updated.minor == _current_version.minor
             assert updated.patch == _current_version.patch
+            if version.label is not None:
+                assert updated.label == version.label
+        
+        if version.label is not None:
+            assert updated.label == _initial_version
     finally:
         for p in touched_file_paths:
             os.system(f"git restore {p}")
@@ -489,7 +489,7 @@ if __name__ == "__main__":
                 version = Version(current.major, current.minor, current.patch + 1)
 
         update_version(
-            release_type=ReleaseType.APPROVED if args.approve else ReleaseType.CANDIDATE,
-            timestamp=datetime.now(),
             version=version,
+            timestamp=datetime.now(),
+            approved=args.approve,
         )

--- a/doc/version.py
+++ b/doc/version.py
@@ -1,7 +1,8 @@
 # MODFLOW 6 version file automatically created using...update_version.py
-# created on...December 09, 2022 20:57:08
+# created on...June 03, 2023 00:06:50
 
 major = 6
 minor = 5
 micro = 0
-__version__ = '{:d}.{:d}.{:d}'.format(major, minor, micro)
+label = 'prt'
+__version__ = '{:d}.{:d}.{:d}{}'.format(major, minor, micro, label)

--- a/doc/version.tex
+++ b/doc/version.tex
@@ -1,3 +1,3 @@
-\newcommand{\modflowversion}{mf6.5.0rc}
-\newcommand{\modflowdate}{December 09, 2022}
+\newcommand{\modflowversion}{mf6.5.0-prt}
+\newcommand{\modflowdate}{June 03, 2023}
 \newcommand{\currentmodflowversion}{Version \modflowversion---\modflowdate}

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'MODFLOW 6',
   'fortran',
-  version: '6.5.0',
+  version: '6.5.0-prt',
   meson_version: '>= 0.59.0',
   default_options : [
     'b_vscrt=static_from_buildtype', # Link runtime libraries statically on Windows

--- a/src/Utilities/version.f90
+++ b/src/Utilities/version.f90
@@ -16,7 +16,7 @@ module VersionModule
   ! -- modflow 6 version
   integer(I4B), parameter :: IDEVELOPMODE = 1
   character(len=*), parameter :: VERSIONNUMBER = '6.5.0'
-  character(len=*), parameter :: VERSIONTAG = ' Release Candidate 12/09/2022'
+  character(len=*), parameter :: VERSIONTAG = '-prt 06/03/2023'
   character(len=40), parameter :: VERSION = VERSIONNUMBER//VERSIONTAG
   character(len=10), parameter :: MFVNAM = ' 6'
   character(len=*), parameter :: MFTITLE = &

--- a/version.txt
+++ b/version.txt
@@ -1,7 +1,8 @@
 # MODFLOW 6 version file automatically created using...update_version.py
-# created on...December 09, 2022 20:57:08
+# created on...June 03, 2023 00:06:50
 
 major = 6
 minor = 5
 micro = 0
-__version__ = '{:d}.{:d}.{:d}'.format(major, minor, micro)
+label = 'prt'
+__version__ = '{:d}.{:d}.{:d}{}'.format(major, minor, micro, label)


### PR DESCRIPTION
* add nightly build workflow `nightly.yml`
* add optional label to versioning mechanism
* update version with '-prtdev' label

The new workflow will build and post a distribution on this repo every night. The workflow can also be triggered manually.

It may be possible to replace the version label mechanism with [one of the solutions here](https://github.com/modflowpy/flopy/issues/1664), but I'm not sure &mdash; we may need an ad hoc solution like the one this PR introduces, since mf6 is not a Python package.