### PR TITLE
manual merge from coords-on-demand

### DIFF
--- a/make/makefile
+++ b/make/makefile
@@ -5,37 +5,37 @@ include ./makedefaults
 
 # Define the source file directories
 SOURCEDIR1=../src
-SOURCEDIR2=../src/Exchange
-SOURCEDIR3=../src/Distributed
-SOURCEDIR4=../src/Solution
-SOURCEDIR5=../src/Solution/LinearMethods
-SOURCEDIR6=../src/Solution/ParticleTracker
-SOURCEDIR7=../src/Solution/PETSc
-SOURCEDIR8=../src/Timing
-SOURCEDIR9=../src/Utilities
-SOURCEDIR10=../src/Utilities/Idm
-SOURCEDIR11=../src/Utilities/Idm/selector
-SOURCEDIR12=../src/Utilities/Idm/mf6blockfile
-SOURCEDIR13=../src/Utilities/TimeSeries
-SOURCEDIR14=../src/Utilities/Memory
-SOURCEDIR15=../src/Utilities/OutputControl
-SOURCEDIR16=../src/Utilities/ArrayRead
-SOURCEDIR17=../src/Utilities/Libraries
-SOURCEDIR18=../src/Utilities/Libraries/rcm
+SOURCEDIR2=../src/Distributed
+SOURCEDIR3=../src/Solution
+SOURCEDIR4=../src/Solution/LinearMethods
+SOURCEDIR5=../src/Solution/ParticleTracker
+SOURCEDIR6=../src/Solution/PETSc
+SOURCEDIR7=../src/Model
+SOURCEDIR8=../src/Model/GroundWaterTransport
+SOURCEDIR9=../src/Model/GroundWaterFlow
+SOURCEDIR10=../src/Model/ParticleTracking
+SOURCEDIR11=../src/Model/ModelUtilities
+SOURCEDIR12=../src/Model/Geometry
+SOURCEDIR13=../src/Model/Connection
+SOURCEDIR14=../src/Utilities
+SOURCEDIR15=../src/Utilities/TimeSeries
+SOURCEDIR16=../src/Utilities/OutputControl
+SOURCEDIR17=../src/Utilities/ArrayRead
+SOURCEDIR18=../src/Utilities/Libraries
 SOURCEDIR19=../src/Utilities/Libraries/blas
 SOURCEDIR20=../src/Utilities/Libraries/sparskit2
-SOURCEDIR21=../src/Utilities/Libraries/daglib
-SOURCEDIR22=../src/Utilities/Libraries/sparsekit
-SOURCEDIR23=../src/Utilities/Vector
-SOURCEDIR24=../src/Utilities/Matrix
-SOURCEDIR25=../src/Utilities/Observation
-SOURCEDIR26=../src/Model
-SOURCEDIR27=../src/Model/Connection
-SOURCEDIR28=../src/Model/ParticleTracking
-SOURCEDIR29=../src/Model/GroundWaterTransport
-SOURCEDIR30=../src/Model/ModelUtilities
-SOURCEDIR31=../src/Model/GroundWaterFlow
-SOURCEDIR32=../src/Model/Geometry
+SOURCEDIR21=../src/Utilities/Libraries/rcm
+SOURCEDIR22=../src/Utilities/Libraries/daglib
+SOURCEDIR23=../src/Utilities/Libraries/sparsekit
+SOURCEDIR24=../src/Utilities/Idm
+SOURCEDIR25=../src/Utilities/Idm/selector
+SOURCEDIR26=../src/Utilities/Idm/mf6blockfile
+SOURCEDIR27=../src/Utilities/Memory
+SOURCEDIR28=../src/Utilities/Observation
+SOURCEDIR29=../src/Utilities/Vector
+SOURCEDIR30=../src/Utilities/Matrix
+SOURCEDIR31=../src/Timing
+SOURCEDIR32=../src/Exchange
 
 VPATH = \
 ${SOURCEDIR1} \
@@ -117,9 +117,11 @@ $(OBJDIR)/ObsOutput.o \
 $(OBJDIR)/TimeArraySeries.o \
 $(OBJDIR)/ObsOutputList.o \
 $(OBJDIR)/Observe.o \
+$(OBJDIR)/CellDefn.o \
 $(OBJDIR)/TimeArraySeriesLink.o \
 $(OBJDIR)/ObsUtility.o \
 $(OBJDIR)/ObsContainer.o \
+$(OBJDIR)/UtilMisc.o \
 $(OBJDIR)/GlobalData.o \
 $(OBJDIR)/BudgetFileReader.o \
 $(OBJDIR)/TimeArraySeriesManager.o \
@@ -140,7 +142,6 @@ $(OBJDIR)/ims8reordering.o \
 $(OBJDIR)/TernaryUtil.o \
 $(OBJDIR)/Ternary.o \
 $(OBJDIR)/TrackData.o \
-$(OBJDIR)/CellDefn.o \
 $(OBJDIR)/VirtualBase.o \
 $(OBJDIR)/STLVecInt.o \
 $(OBJDIR)/InputDefinition.o \
@@ -154,7 +155,6 @@ $(OBJDIR)/ims8base.o \
 $(OBJDIR)/TernarySolveTrack.o \
 $(OBJDIR)/SubcellTri.o \
 $(OBJDIR)/Method.o \
-$(OBJDIR)/UtilMisc.o \
 $(OBJDIR)/SubcellRect.o \
 $(OBJDIR)/VirtualDataLists.o \
 $(OBJDIR)/VirtualDataContainer.o \

--- a/src/Model/ParticleTracking/prt1prp1.f90
+++ b/src/Model/ParticleTracking/prt1prp1.f90
@@ -189,18 +189,22 @@ contains
     ! call mem_deallocate(this%porosity)
     ! call mem_deallocate(this%retfactor)
     ! call mem_deallocate(this%izone)
+    !
+    deallocate (this%partlist%irpt)
+    deallocate (this%partlist%iprp)
+    deallocate (this%partlist%istopweaksink)
+    deallocate (this%partlist%istopzone)
+    deallocate (this%partlist%iTrackingDomain)
+    deallocate (this%partlist%iTrackingDomainBoundary)
+    deallocate (this%partlist%izone)
+    deallocate (this%partlist%istatus)
     deallocate (this%partlist%x) ! kluge note: use mem_deallocate for these arrays
     deallocate (this%partlist%y)
     deallocate (this%partlist%z)
-    deallocate (this%partlist%iTrackingDomain)
-    deallocate (this%partlist%iTrackingDomainBoundary)
     deallocate (this%partlist%trelease)
     deallocate (this%partlist%tstop)
     deallocate (this%partlist%ttrack)
-    deallocate (this%partlist%istopweaksink)
-    deallocate (this%partlist%istopzone)
-    deallocate (this%partlist%istatus)
-    deallocate (this%partlist%irpt)
+    !
     deallocate (this%partlist) ! kluge note: structure of arrays
     call mem_deallocate(this%massrls)
     !
@@ -265,23 +269,25 @@ contains
     !                   this%memoryPath)
     ! call mem_allocate(this%izone, this%dis%nodes, 'IZONE', this%memoryPath)
     allocate (this%partlist) ! kluge note: structure of arrays
-    ! allocate(this%partlist%velmult(this%npartmax))
-    allocate (this%partlist%x(this%npartmax)) ! kluge note: nprtmax is the initial max dimension
-    allocate (this%partlist%y(this%npartmax)) ! kluge note: use mem_allocate for these arrays
-    allocate (this%partlist%z(this%npartmax))
+    allocate (this%partlist%irpt(this%npartmax))
+    allocate (this%partlist%iprp(this%npartmax))
     ! kluge note: ditch crazy dims
     allocate (this%partlist%iTrackingDomain(this%npartmax, &
                                             levelMin:levelMax))
     ! kluge note: ditch crazy dims
     allocate (this%partlist%iTrackingDomainBoundary(this%npartmax, &
                                                     levelMin:levelMax))
+    allocate (this%partlist%izone(this%npartmax))
+    allocate (this%partlist%istatus(this%npartmax))
+    allocate (this%partlist%x(this%npartmax)) ! kluge note: nprtmax is the initial max dimension
+    allocate (this%partlist%y(this%npartmax)) ! kluge note: use mem_allocate for these arrays
+    allocate (this%partlist%z(this%npartmax))
     allocate (this%partlist%trelease(this%npartmax))
     allocate (this%partlist%tstop(this%npartmax))
     allocate (this%partlist%ttrack(this%npartmax))
     allocate (this%partlist%istopweaksink(this%npartmax))
     allocate (this%partlist%istopzone(this%npartmax))
-    allocate (this%partlist%istatus(this%npartmax))
-    allocate (this%partlist%irpt(this%npartmax))
+
     call mem_allocate(this%massrls, this%nreleasepts, 'MASSRLS', this%memoryPath)
     !
     ! -- Intialize

--- a/src/Solution/ParticleTracker/Method.f90
+++ b/src/Solution/ParticleTracker/Method.f90
@@ -71,6 +71,9 @@ contains
       ! -- continue delegating
       call submethod%apply(particle, tmax)
       !
+      ! -- Store particle trackdata as appropriate
+      call submethod%trackdata%add_track_data(particle, reason=1, level=levelNext)
+      !
       ! -- Advance particle
       call advance(this, particle, levelNext, submethod, isStillAdvancing)
       !
@@ -88,29 +91,7 @@ contains
     integer :: levelNext
     class(MethodType), pointer :: submethod
     logical :: isStillAdvancing
-    ! local
-    ! character(len=40) :: typeSubdomain ! kluge???
-    integer :: ip !, iSubdomain
     !
-    ! ! -- Check whether the particle stopped advancing within the last tracking
-    ! ! -- subdomain or has exited the tracking domain. If not, advance to the next
-    ! ! -- subdomain.
-    ! ip = particle%ipart
-    ! typeSubdomain = submethod%trackingDomainType
-    ! if (particle%iTrackingDomainBoundary(levelNext).eq.0) then
-    !   particle%iTrackingDomainBoundary = 0        ! kluge???
-    !   isStillAdvancing = .false.
-    ! else
-    !   call this%pass(particle)
-    !   iSubdomain = particle%iTrackingDomain(levelNext)
-    !   if (iSubdomain.lt.0) then
-    !     isStillAdvancing = .false.
-    !   end if
-    ! end if
-    ! -- Check whether the particle terminated within the last tracking
-    ! -- subdomain. If not, advance to the next subdomain, if there is one.
-    ip = particle%ipart
-    ! if (particle%iTrackingDomainBoundary(levelNext).eq.0) then
     if (particle%istatus .ne. -1) then
       particle%iTrackingDomainBoundary = 0 ! kluge???
       isStillAdvancing = .false.
@@ -120,31 +101,6 @@ contains
         isStillAdvancing = .false.
       end if
     end if
-    ! ip = particle%ipart
-    ! if (particle%istatus.eq.-1) then
-    !   ! -- Particle not finished or terminated
-    !   if (particle%iTrackingDomainBoundary(levelNext-1).eq.0) then  ! kluge note: pass in level instead of levelNext???
-    !     ! -- Particle in domain interior, so pass to next subdomain
-    !     call this%pass(particle)
-    !     if (particle%istatus.ne.-1) then
-    !       ! -- Particle finished or terminated, so no longer advancing
-    !       ! -- in current domain
-    !       isStillAdvancing = .false.
-    !     else if (particle%iTrackingDomainBoundary(levelNext-1).ne.0) then
-    !       ! -- Particle is at domain boundary, so no longer advancing
-    !       ! -- in current domain
-    !       isStillAdvancing = .false.
-    !     end if
-    !   else
-    !     ! -- Particle is at domain boundary, so no longer advancing
-    !     ! -- in current domain
-    !     isStillAdvancing = .false.
-    !   end if
-    ! else
-    !   ! -- Particle finished or terminated, so no longer advancing
-    !   ! -- in current domain
-    !   isStillAdvancing = .false.
-    ! end if
     !
     return
     !

--- a/src/Solution/ParticleTracker/MethodCellPassToBot.f90
+++ b/src/Solution/ParticleTracker/MethodCellPassToBot.f90
@@ -100,36 +100,29 @@ contains
   subroutine apply_mCVP(this, particle, tmax)
     ! -- modules
     use UtilMiscModule
-    use TdisModule, only: kper, kstp
     ! -- dummy
     class(MethodCellPassToBotType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
     real(DP), intent(in) :: tmax
-    ! doubleprecision :: initialTime,maximumTime,t   ! kluge not in arg list yet
-    ! -- local
-    integer(I4B) :: ntrack
+    !
+    ! -- Update particle zone
+    particle%izone = this%cellDefn%izone
     !
     if (this%cellDefn%izone .ne. 0) then
       if (particle%istopzone .eq. this%cellDefn%izone) then
         ! -- Stop zone
         ! particle%iTrackingDomainBoundary(3) = 0
         particle%istatus = 6
-        ! write(*,'(A,I,A,I)') "particle ", particle%ipart, " terminated in stop zone cell: ", particle%iTrackingDomain(2)  ! kluge
-        ! return
       end if
     else if (this%cellDefn%inoexitface .ne. 0) then
       ! -- No exit face
       ! particle%iTrackingDomainBoundary(3) = 0
       particle%istatus = 5
-      ! write(*,'(A,I,A,I)') "particle ", particle%ipart, " terminated at cell w/ no exit face: ", particle%iTrackingDomain(2)  ! kluge
-      ! return
     else if (particle%istopweaksink .ne. 0) then
       if (this%cellDefn%iweaksink .ne. 0) then
         ! -- Weak sink
         ! particle%iTrackingDomainBoundary(3) = 0
         particle%istatus = 3
-        ! write(*,'(A,I,A,I)')  "particle ", particle%ipart, " terminated at weak sink cell: ", particle%iTrackingDomain(2)  ! kluge
-        ! return
       end if
     else
       !
@@ -140,25 +133,7 @@ contains
     end if
     !
     ! -- Store track data
-    ntrack = this%trackdata%nrows + 1 ! kluge?
-    this%trackdata%nrows = ntrack
-    this%trackdata%kper(ntrack) = kper
-    this%trackdata%kstp(ntrack) = kstp
-    this%trackdata%iprp(ntrack) = particle%iprp
-    this%trackdata%irpt(ntrack) = particle%ipart
-    this%trackdata%icell(ntrack) = particle%iTrackingDomain(2)
-    this%trackdata%izone(ntrack) = this%cellDefn%izone
-    this%trackdata%istatus(ntrack) = particle%istatus
-    if (particle%istatus > 1) then
-      this%trackdata%ireason(ntrack) = 3 ! termination
-    else
-      this%trackdata%ireason(ntrack) = 1 ! crossing cell boundary
-    end if
-    this%trackdata%trelease(ntrack) = particle%trelease
-    this%trackdata%t(ntrack) = particle%ttrack
-    this%trackdata%x(ntrack) = particle%x
-    this%trackdata%y(ntrack) = particle%y
-    this%trackdata%z(ntrack) = particle%z
+    call this%trackdata%add_track_data(particle, reason=1)
     !
     return
     !

--- a/src/Solution/ParticleTracker/MethodSubcellTernary.f90
+++ b/src/Solution/ParticleTracker/MethodSubcellTernary.f90
@@ -4,6 +4,7 @@ module MethodSubcellTernaryModule
   use MethodModule
   use SubcellTriModule
   use ParticleModule
+  use TrackDataModule, only: TrackDataType
   use Ternary
   use TernaryUtil, only: rotate, skew
   use TernarySolveTrack, only: traverse_triangle, step_analytical, canonical
@@ -59,12 +60,17 @@ contains
   end subroutine destroy
 
   !> @brief Initialize a ternary subcell-method object
-  subroutine init(this, subcellTri)
+  subroutine init(this, subcellTri, trackdata)
     ! -- dummy
     class(MethodSubcellTernaryType), intent(inout) :: this
     type(SubcellTriType), pointer :: subcellTri
+    type(TrackDataType), pointer :: trackdata
     !
+    ! -- Set pointer to subcell definition
     this%subcellTri => subcellTri
+    !
+    ! -- Set pointer to particle track data
+    this%trackdata => trackdata
     !
     return
     !
@@ -185,9 +191,11 @@ contains
       ! particle%iTrackingDomainBoundary(3) = exitFace
       ! particle%istatus = 5
       ! return
+
+      ! kluge note: todo identify particle by "composite key" (not just irpt)
       print *, "======================================"
       print *, "Subcell with no exit face" ! kluge
-      print *, "Particle ", particle%ipart
+      print *, "Particle ", particle%irpt
       print *, "Cell ", particle%iTrackingDomain(2)
       print *, "======================================"
       !!pause

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -1,6 +1,9 @@
 module ParticleModule
 
+  use KindModule, only: DP, I4B, LGP
+  use ConstantsModule, only: DZERO, DONE
   use GlobalDataModule
+  use UtilMiscModule, only: transform_coords, modify_transf
   implicit none
 
   private
@@ -11,50 +14,72 @@ module ParticleModule
   ! -- Define the particle type (ParticleType)
   type ParticleType
     private
-    integer, public :: ipart ! particle number (index)
-    integer, public :: iprp ! particle release point number (index)
-    ! integer, public :: igroup ! index of particle group to which the particle belongs
+
+    ! provenance/metadata
     ! integer, public :: imodel ! index of model to which the particle currently belongs
-    ! double precision, public :: velmult ! velocity multiplier for the particle (determined by group)
-    double precision, public :: x ! model x coord of particle
-    double precision, public :: y ! model y coord of particle
-    double precision, public :: z ! model z coord of particle
-    double precision, public :: xlocal ! local x coord of particle
-    double precision, public :: ylocal ! local y coord of particle
-    double precision, public :: zlocal ! local z coord of particle
-    integer, allocatable, public :: iTrackingDomain(:) ! array of indices for domains in the tracking domain hierarchy
-    integer, allocatable, public :: iTrackingDomainBoundary(:) ! array of indices for tracking domain boundaries
-    double precision, public :: trelease ! particle release time
-    double precision, public :: tstop ! particle stop time
-    double precision, public :: ttrack ! time to which particle has been tracked
-    integer, public :: istopweaksink !< weak sink option: 0 = do not stop, 1 = stop
-    integer, public :: istopzone !< stop zone number
-    integer, public :: istatus !< particle status
-    integer, public :: irpt !< release point number
+    integer(I4B), public :: irpt !< release point number
+    integer(I4B), public :: iprp ! particle release point number (index)
+
+    ! stop criteria
+    integer(I4B), public :: istopweaksink !< weak sink option: 0 = do not stop, 1 = stop
+    integer(I4B), public :: istopzone !< stop zone number
+
+    ! tracking domain
+    integer(I4B), allocatable, public :: iTrackingDomain(:) ! array of indices for domains in the tracking domain hierarchy
+    integer(I4B), allocatable, public :: iTrackingDomainBoundary(:) ! array of indices for tracking domain boundaries
+
+    ! track data
+    integer(I4B), public :: izone !< current zone number
+    integer(I4B), public :: istatus !< particle status
+    real(DP), public :: x ! model x coord of particle
+    real(DP), public :: y ! model y coord of particle
+    real(DP), public :: z ! model z coord of particle
+    real(DP), public :: trelease ! particle release time
+    real(DP), public :: tstop ! particle stop time
+    real(DP), public :: ttrack ! time to which particle has been tracked
+
+    ! transformation
+    logical(LGP), public :: isTransformed !< indicates whether coordinates have been transformed from model to local coordinates
+    real(DP), public :: xOrigin !< x origin for coordinate transformation from model to local
+    real(DP), public :: yOrigin !< y origin for coordinate transformation from model to local
+    real(DP), public :: zOrigin !< z origin for coordinate transformation from model to local
+    real(DP), public :: sinrot !< sine of rotation angle for coordinate transformation from model to local
+    real(DP), public :: cosrot !< cosine of rotation angle for coordinate transformation from model to local
 
   contains
     procedure, public :: destroy => destroy_particle ! destructor for the particle
+    procedure, public :: set_transf
+    procedure, public :: reset_transf
+    procedure, public :: transf_coords
+    procedure, public :: get_model_coords
   end type ParticleType
 
   ! -- Define the particle list type (ParticleListType)  ! kluge note: use separate module???
   type ParticleListType
-    ! type(ParticleType), pointer :: particle
-    ! double precision, allocatable, public :: velmult(:) ! velocity multiplier for the particle (determined by group)
-    double precision, allocatable, public :: x(:) ! model x coord of particle
-    double precision, allocatable, public :: y(:) ! model y coord of particle
-    double precision, allocatable, public :: z(:) ! model z coord of particle
-    ! double precision, allocatable, public :: xlocal(:) ! local x coord of particle
-    ! double precision, allocatable, public :: ylocal(:) ! local y coord of particle
-    ! double precision, allocatable, public :: zlocal(:) ! local z coord of particle
-    integer, allocatable, public :: iTrackingDomain(:, :) ! array of indices for domains in the tracking domain hierarchy
-    integer, allocatable, public :: iTrackingDomainBoundary(:, :) ! array of indices for tracking domain boundaries
-    double precision, allocatable, public :: trelease(:) ! particle release time
-    double precision, allocatable, public :: tstop(:) ! particle stop time
-    double precision, allocatable, public :: ttrack(:) ! time to which particle has been tracked
-    integer, allocatable, public :: istopweaksink(:) !< weak sink option: 0 = do not stop, 1 = stop
-    integer, allocatable, public :: istopzone(:) !< stop zone number
-    integer, allocatable, public :: istatus(:) !< particle status
-    integer, allocatable, public :: irpt(:) !< release point number
+
+    ! provenance/metadata
+    ! integer, public :: imodel ! index of model to which the particle currently belongs
+    integer(I4B), allocatable, public :: irpt(:) !< release point number
+    integer(I4B), allocatable, public :: iprp(:) ! particle release point number (index)
+
+    ! stopping criteria
+    integer(I4B), allocatable, public :: istopweaksink(:) !< weak sink option: 0 = do not stop, 1 = stop
+    integer(I4B), allocatable, public :: istopzone(:) !< stop zone number
+
+    ! tracking domain
+    integer(I4B), allocatable, public :: iTrackingDomain(:, :) ! array of indices for domains in the tracking domain hierarchy
+    integer(I4B), allocatable, public :: iTrackingDomainBoundary(:, :) ! array of indices for tracking domain boundaries
+
+    ! track data
+    integer(I4B), allocatable, public :: izone(:) !< current zone number
+    integer(I4B), allocatable, public :: istatus(:) !< particle status
+    real(DP), allocatable, public :: x(:) ! model x coord of particle
+    real(DP), allocatable, public :: y(:) ! model y coord of particle
+    real(DP), allocatable, public :: z(:) ! model z coord of particle
+    real(DP), allocatable, public :: trelease(:) ! particle release time
+    real(DP), allocatable, public :: tstop(:) ! particle stop time
+    real(DP), allocatable, public :: ttrack(:) ! time to which particle has been tracked
+
   end type ParticleListType
 
 contains
@@ -79,5 +104,104 @@ contains
     deallocate (this%iTrackingDomainBoundary)
     return
   end subroutine destroy_particle
+
+  !> @brief Directly set transformation from model coordinates
+  !! to particle's local coordinates
+  !<
+  subroutine set_transf(this, xOrigin, yOrigin, zOrigin, sinrot, cosrot)
+    ! -- dummy
+    class(ParticleType), intent(inout) :: this
+    real(DP), intent(in) :: xOrigin
+    real(DP), intent(in) :: yOrigin
+    real(DP), intent(in) :: zOrigin
+    real(DP), intent(in) :: sinrot
+    real(DP), intent(in) :: cosrot
+    ! -- local
+    !
+    this%xOrigin = xOrigin
+    this%yOrigin = yOrigin
+    this%zOrigin = zOrigin
+    this%sinrot = sinrot
+    this%cosrot = cosrot
+    !
+    this%isTransformed = .true.
+    !
+    return
+  end subroutine set_transf
+
+  subroutine transf_coords(this, xOrigin_opt, yOrigin_opt, zOrigin_opt, &
+                           sinrot_opt, cosrot_opt, invert_opt)
+    ! -- dummy
+    class(ParticleType), intent(inout) :: this
+    real(DP), intent(in), optional :: xOrigin_opt
+    real(DP), intent(in), optional :: yOrigin_opt
+    real(DP), intent(in), optional :: zOrigin_opt
+    real(DP), intent(in), optional :: sinrot_opt
+    real(DP), intent(in), optional :: cosrot_opt
+    logical(LGP), intent(in), optional :: invert_opt
+    !
+    ! -- Transform particle's coordinates
+    call transform_coords(this%x, this%y, this%z, this%x, this%y, this%z, &
+                          xOrigin_opt, yOrigin_opt, zOrigin_opt, &
+                          sinrot_opt, cosrot_opt, invert_opt)
+    !
+    ! -- Modify transformation from model coordinates to particle's new
+    ! -- local coordinates by incorporating this latest transformation
+    call modify_transf(this%xOrigin, this%yOrigin, this%zOrigin, &
+                       this%sinrot, this%cosrot, &
+                       xOrigin_opt, yOrigin_opt, zOrigin_opt, &
+                       sinrot_opt, cosrot_opt, invert_opt)
+    ! -- Set isTransformed flag to true. Note that there is no check
+    ! -- to see whether the modification brings the coordinates back
+    ! -- to model coordinates (in which case the origin would be very
+    ! -- close to zero and sinrot and cosrot would be very close to 0.
+    ! -- and 1., respectively, allowing for roundoff error).
+    this%isTransformed = .true.
+    !
+    return
+  end subroutine transf_coords
+
+  !> @brief Reset coordinate transformation to none
+  !<
+  subroutine reset_transf(this)
+    ! -- dummy
+    class(ParticleType), intent(inout) :: this
+    ! -- local
+    !
+    this%xOrigin = DZERO
+    this%yOrigin = DZERO
+    this%zOrigin = DZERO
+    this%sinrot = DZERO
+    this%cosrot = DONE
+    !
+    this%isTransformed = .false.
+    !
+    return
+  end subroutine reset_transf
+
+  !> @brief Return the particle's model coordinates
+  !<
+  subroutine get_model_coords(this, xmodel, ymodel, zmodel)
+    ! -- dummy
+    class(ParticleType), intent(inout) :: this
+    real(DP) :: xmodel
+    real(DP) :: ymodel
+    real(DP) :: zmodel
+    ! -- local
+    !
+    if (this%isTransformed) then
+      ! -- Transform back from local to model coordinates
+      call transform_coords(this%x, this%y, this%z, xmodel, ymodel, zmodel, &
+                            this%xOrigin, this%yOrigin, this%zOrigin, &
+                            this%sinrot, this%cosrot, .true.)
+    else
+      ! -- Already in model coordinates
+      xmodel = this%x
+      ymodel = this%y
+      zmodel = this%z
+    end if
+    !
+    return
+  end subroutine get_model_coords
 
 end module ParticleModule

--- a/src/Solution/ParticleTracker/UtilMisc.f90
+++ b/src/Solution/ParticleTracker/UtilMisc.f90
@@ -1,5 +1,7 @@
 module UtilMiscModule
 
+  use KindModule, only: DP, I4B, LGP
+  use ConstantsModule, only: DZERO, DONE
   use CellDefnModule, only: VertexType
 
   interface allocate_as_needed
@@ -11,7 +13,7 @@ contains
 
   function FirstNonBlank(string) result(firstChar)
     implicit none
-    character(len=*), intent(in) :: string
+    character(len=*) string
     integer :: firstChar, length, n
 
     firstChar = 0
@@ -27,7 +29,6 @@ contains
 
   end function FirstNonBlank
 
-!------------------------------------------------------
   subroutine GetLayerRowColumn(cellNumber, layer, row, column, nlay, nrow, ncol)
     implicit none
     integer, intent(in) :: cellNumber, nlay, nrow, ncol
@@ -51,7 +52,6 @@ contains
 
   end subroutine GetLayerRowColumn
 
-!------------------------------------------------------
   subroutine ModExt(a, p, r, n)
     implicit none
     integer, intent(in) :: a, p
@@ -67,12 +67,7 @@ contains
 
   end subroutine ModExt
 
-! --------------------------------------------------------------------
-! INTEGER FUNCTION  FindMinimum():
-!    This function returns the location of the minimum in the section
-! between StartValue and EndValue.
-! --------------------------------------------------------------------
-
+  !> @brief Find the minimum between StartValue and EndValue
   INTEGER FUNCTION FindMinimum(x, StartValue, EndValue)
     IMPLICIT NONE
     INTEGER, DIMENSION(1:), INTENT(IN) :: x
@@ -92,11 +87,7 @@ contains
     FindMinimum = Location ! return the position
   END FUNCTION FindMinimum
 
-! --------------------------------------------------------------------
-! SUBROUTINE  Swap():
-!    This subroutine swaps the values of its two formal arguments.
-! --------------------------------------------------------------------
-
+  !> @brief Swaps the values of the two arguments
   SUBROUTINE Swap(a, b)
     IMPLICIT NONE
     INTEGER, INTENT(INOUT) :: a, b
@@ -107,12 +98,7 @@ contains
     b = Temp
   END SUBROUTINE Swap
 
-! --------------------------------------------------------------------
-! SUBROUTINE  Sort():
-!    This subroutine receives an array x() and sorts it into ascending
-! order.
-! --------------------------------------------------------------------
-
+  !> @brief Sort the array in ascending order
   SUBROUTINE Sort(x, Size)
     IMPLICIT NONE
     INTEGER, INTENT(IN) :: Size
@@ -126,20 +112,14 @@ contains
     END DO
   END SUBROUTINE Sort
 
+  !> @brief Allocates or reallocates/resizes an integer(kind=1)
+  !! array to meet or exceed a specified minimum dimension.
+  !! kluge note: is there a better way than these new "allocate_as_needed" subroutines???
   subroutine allocate_as_needed_int1(i1array, mindim)
-! ******************************************************************************
-! allocate_as_needed_int1 -- Allocates or reallocates/resizes an integer(kind=1)
-!                            array to meet or exceed a specified minimum
-!                            dimension
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
     ! -- dummy
     integer(kind=1), allocatable, intent(inout) :: i1array(:)
     integer, intent(in) :: mindim
-! ------------------------------------------------------------------------------
     !
     if (.not. ALLOCATED(i1array)) then
       allocate (i1array(mindim))
@@ -151,20 +131,13 @@ contains
     return
   end subroutine allocate_as_needed_int1
 
+  !> @brief Allocates or reallocates/resizes a double-precision
+  !! array to meet or exceed a specified minimum dimension
   subroutine allocate_as_needed_dble(darray, mindim)
-! ******************************************************************************
-! allocate_as_needed_dble -- Allocates or reallocates/resizes a double-precision
-!                            array to meet or exceed a specified minimum
-!                            dimension
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
     ! -- dummy
     double precision, allocatable, intent(inout) :: darray(:)
     integer, intent(in) :: mindim
-! ------------------------------------------------------------------------------
     !
     if (.not. ALLOCATED(darray)) then
       allocate (darray(mindim))
@@ -176,20 +149,13 @@ contains
     return
   end subroutine allocate_as_needed_dble
 
+  !> @brief Allocates or reallocates/resizes a vertex
+  !! array to meet or exceed a specified minimum dimension
   subroutine allocate_as_needed_vert(varray, mindim)
-! ******************************************************************************
-! allocate_as_needed_vert -- Allocates or reallocates/resizes a vertex
-!                            array to meet or exceed a specified minimum
-!                            dimension
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
     ! -- dummy
     class(VertexType), allocatable, intent(inout) :: varray(:)
     integer, intent(in) :: mindim
-! ------------------------------------------------------------------------------
     !
     if (.not. ALLOCATED(varray)) then
       allocate (varray(mindim))
@@ -201,20 +167,13 @@ contains
     return
   end subroutine allocate_as_needed_vert
 
+  !> @brief Allocates or reallocates/resizes a logical
+  !! array to meet or exceed a specified minimum dimension
   subroutine allocate_as_needed_logical(larray, mindim)
-! ******************************************************************************
-! allocate_as_needed_logical -- Allocates or reallocates/resizes a logical
-!                               array to meet or exceed a specified minimum
-!                               dimension
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
     ! -- dummy
     logical, allocatable, intent(inout) :: larray(:)
     integer, intent(in) :: mindim
-! ------------------------------------------------------------------------------
     !
     if (.not. ALLOCATED(larray)) then
       allocate (larray(mindim))
@@ -226,65 +185,217 @@ contains
     return
   end subroutine allocate_as_needed_logical
 
-  subroutine transform_coords(xin, yin, zin, xOrigin, yOrigin, zOrigin, &
-                              sinrot, cosrot, invert, xout, yout, zout)
-! ******************************************************************************
-! transform_coords -- Translation and 2D rotation of coordinates,
-!                     with option to invert transformation
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
+  !> @brief 3D translation and 2D rotation of coordinates
+  !! with option to invert transformation
+  subroutine transform_coords(xin, yin, zin, xout, yout, zout, &
+                              xOrigin_opt, yOrigin_opt, zOrigin_opt, &
+                              sinrot_opt, cosrot_opt, invert_opt)
     implicit none
     ! -- dummy
     double precision :: xin, yin, zin
-    double precision :: xOrigin, yOrigin, zOrigin
-    double precision :: sinrot, cosrot
-    logical :: invert
     double precision :: xout, yout, zout
+    double precision, optional :: xOrigin_opt, yOrigin_opt, zOrigin_opt
+    double precision, optional :: sinrot_opt, cosrot_opt
+    logical, optional :: invert_opt
     ! -- local
+    logical(LGP) :: isTranslation_add, isRotation_add, invert_add
+    real(DP) :: xOrigin_add, yOrigin_add, zOrigin_add, sinrot_add, cosrot_add
     double precision :: x, y
-! ------------------------------------------------------------------------------
     !
-    if (.not. invert) then
-      xout = xin - xOrigin
-      yout = yin - yOrigin
-      zout = zin - zOrigin
-      if (sinrot .ne. 0d0) then
+    ! -- Process option arguments and set defaults and flags
+    call transf_opt_args_prep(xOrigin_add, yOrigin_add, zOrigin_add, &
+                              sinrot_add, cosrot_add, invert_add, &
+                              isTranslation_add, isRotation_add, &
+                              xOrigin_opt, yOrigin_opt, zOrigin_opt, &
+                              sinrot_opt, cosrot_opt, invert_opt)
+    !
+    ! -- Apply transformation or its inverse
+    if (.not. invert_add) then
+      ! -- Apply transformation to coordinates
+      if (isTranslation_add) then
+        xout = xin - xOrigin_add
+        yout = yin - yOrigin_add
+        zout = zin - zOrigin_add
+      else
+        xout = xOrigin_add
+        yout = yOrigin_add
+        zout = zOrigin_add
+      end if
+      if (isRotation_add) then
         x = xout
         y = yout
-        xout = x * cosrot + y * sinrot
-        yout = -x * sinrot + y * cosrot
+        xout = x * cosrot_add + y * sinrot_add
+        yout = -x * sinrot_add + y * cosrot_add
       end if
     else
-      if (sinrot .ne. 0d0) then
-        x = xin * cosrot - yin * sinrot
-        y = xin * sinrot + yin * cosrot
+      ! -- Apply inverse of transformation to coordinates
+      if (isRotation_add) then
+        x = xin * cosrot_add - yin * sinrot_add
+        y = xin * sinrot_add + yin * cosrot_add
       else
         x = xin
         y = yin
       end if
-      xout = x + xOrigin
-      yout = y + yOrigin
-      zout = zin + zOrigin
+      if (isTranslation_add) then
+        xout = x + xOrigin_add
+        yout = y + yOrigin_add
+        zout = zin + zOrigin_add
+      end if
     end if
     !
     return
     !
   end subroutine transform_coords
 
+  !> @brief Modify transformation by applying an additional
+  !! 3D translation and 2D rotation
+  subroutine modify_transf(xOrigin, yOrigin, zOrigin, sinrot, cosrot, &
+                           xOrigin_opt, yOrigin_opt, zOrigin_opt, &
+                           sinrot_opt, cosrot_opt, invert_opt)
+    implicit none
+    ! -- dummy
+    double precision :: xOrigin, yOrigin, zOrigin
+    double precision :: sinrot, cosrot
+    double precision, optional :: xOrigin_opt, yOrigin_opt, zOrigin_opt
+    double precision, optional :: sinrot_opt, cosrot_opt
+    logical, optional :: invert_opt
+    ! -- local
+    logical(LGP) :: isTranslation_add, isRotation_add, invert_add
+    real(DP) :: xOrigin_add, yOrigin_add, zOrigin_add, sinrot_add, cosrot_add
+    real(DP) :: x0, y0, z0, s0, c0
+    !
+    ! -- Process option arguments and set defaults and flags
+    call transf_opt_args_prep(xOrigin_add, yOrigin_add, zOrigin_add, &
+                              sinrot_add, cosrot_add, invert_add, &
+                              isTranslation_add, isRotation_add, &
+                              xOrigin_opt, yOrigin_opt, zOrigin_opt, &
+                              sinrot_opt, cosrot_opt, invert_opt)
+    !
+    ! -- Copy existing transformation into working copy
+    x0 = xOrigin
+    y0 = yOrigin
+    z0 = zOrigin
+    s0 = sinrot
+    c0 = cosrot
+    !
+    ! -- Modify transformation
+    if (.not. invert_add) then
+      !
+      ! -- Apply additional transformation to existing transformation
+      !
+      if (isTranslation_add) then
+        ! -- Calculate modified origin, XOrigin + R^T XOrigin_add, where
+        ! -- XOrigin and XOrigin_add are the existing and additional origin
+        ! -- vectors, respectively, and R^T is the transpose of the existing
+        ! -- rotation matrix
+        call transform_coords(xOrigin_add, yOrigin_add, zOrigin_add, &
+                              xOrigin, yOrigin, zOrigin, &
+                              x0, y0, z0, s0, c0, .true.)
+      end if
+      if (isRotation_add) then
+        ! -- Calculate modified rotation matrix (represented by sinrot
+        ! -- and cosrot) as R_add R, where R and R_add are the existing
+        ! -- and additional rotation matrices, respectively
+        sinrot = cosrot_add * s0 + sinrot_add * c0
+        cosrot = cosrot_add * c0 - sinrot_add * s0
+      end if
+      !
+    else
+      !
+      ! -- Apply inverse of additional transformation to existing transformation
+      !
+      ! -- Calculate modified origin, R^T (XOrigin + R_add XOrigin_add), where
+      ! -- XOrigin and XOrigin_add are the existing and additional origin
+      ! -- vectors, respectively, R^T is the transpose of the existing rotation
+      ! -- matrix, and R_add is the additional rotation matrix
+      if (isTranslation_add) then
+        call transform_coords(-xOrigin_add, -yOrigin_add, zOrigin_add, &
+                              x0, y0, z0, xOrigin, yOrigin, zOrigin, &
+                              -sinrot_add, cosrot_add, .true.)
+      end if
+      xOrigin = c0 * x0 - s0 * y0
+      yOrigin = s0 * x0 + c0 * y0
+      zOrigin = z0
+      if (isRotation_add) then
+        ! -- Calculate modified rotation matrix (represented by sinrot
+        ! -- and cosrot) as R_add^T R, where R and R_add^T are the existing
+        ! -- rotation matirx and the transpose of the additional rotation
+        ! -- matrix, respectively
+        sinrot = cosrot_add * s0 - sinrot_add * c0
+        cosrot = cosrot_add * c0 + sinrot_add * s0
+      end if
+      !
+    end if
+    !
+    return
+    !
+  end subroutine modify_transf
+
+  !> @brief Process option arguments and set defaults and flags
+  !! for transformation operations
+  subroutine transf_opt_args_prep(xOrigin_add, yOrigin_add, zOrigin_add, &
+                                  sinrot_add, cosrot_add, invert_add, &
+                                  isTranslation_add, isRotation_add, &
+                                  xOrigin_opt, yOrigin_opt, zOrigin_opt, &
+                                  sinrot_opt, cosrot_opt, invert_opt)
+    implicit none
+    ! -- dummy
+    double precision :: xOrigin_add, yOrigin_add, zOrigin_add
+    double precision :: sinrot_add, cosrot_add
+    logical :: invert_add, isTranslation_add, isRotation_add
+    double precision, optional :: xOrigin_opt, yOrigin_opt, zOrigin_opt
+    double precision, optional :: sinrot_opt, cosrot_opt
+    logical, optional :: invert_opt
+    ! -- local
+    !
+    isTranslation_add = .false.
+    xOrigin_add = DZERO
+    if (present(xOrigin_opt)) then
+      xOrigin_add = xOrigin_opt
+      isTranslation_add = .true.
+    end if
+    yOrigin_add = DZERO
+    if (present(yOrigin_opt)) then
+      yOrigin_add = yOrigin_opt
+      isTranslation_add = .true.
+    end if
+    zOrigin_add = DZERO
+    if (present(zOrigin_opt)) then
+      zOrigin_add = zOrigin_opt
+      isTranslation_add = .true.
+    end if
+    isRotation_add = .false.
+    sinrot_add = DZERO
+    cosrot_add = DONE
+    if (present(sinrot_opt)) then
+      sinrot_add = sinrot_opt
+      if (present(cosrot_opt)) then
+        cosrot_add = cosrot_opt
+      else
+        ! -- If sinrot_opt is specified but cosrot_opt is not,
+        ! -- default to corresponding non-negative cosrot_add
+        cosrot_add = dsqrt(DONE - sinrot_add * sinrot_add)
+      end if
+      isRotation_add = .true.
+    else if (present(cosrot_opt)) then
+      cosrot_add = cosrot_opt
+      ! -- cosrot_opt is specified but sinrot_opt is not, so
+      ! -- default to corresponding non-negative sinrot_add
+      sinrot_add = dsqrt(DONE - cosrot_add * cosrot_add)
+      isRotation_add = .true.
+    end if
+    invert_add = .false.
+    if (present(invert_opt)) invert_add = invert_opt
+    !
+    return
+    !
+  end subroutine transf_opt_args_prep
+
+  !> @brief Adds a specified amount to an index and "wraps" the result if needed
   function add_wrap(istart, iadd, ilimit) result(iwrapped)
-! ******************************************************************************
-! add_wrap -- Adds a specified amount to an index and "wraps" the result
-!             if necessary
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
     ! -- dummy
     integer :: istart, iadd, ilimit, iwrapped
-! ------------------------------------------------------------------------------
     !
     ! -- Add iadd to istart.  If the result exceeds ilimit, wrap around
     ! -- starting with 1. It is assumed (without checking) that iadd
@@ -299,18 +410,12 @@ contains
     !
   end function add_wrap
 
+  !> @brief Subtracts a specified amount from an index and "wraps" the
+  !! result if necessary
   function subtr_wrap(istart, isubtr, ilimit) result(iwrapped)
-! ******************************************************************************
-! subtr_wrap -- Subtracts a specified amount from an index and "wraps" the
-!               result if necessary
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
     ! -- dummy
     integer :: istart, isubtr, ilimit, iwrapped
-! ------------------------------------------------------------------------------
     !
     ! -- Subtract isubtr from istart.  If the result is less than 1, wrap
     ! -- around starting with ilimit. It is assumed (without checking) that
@@ -325,17 +430,11 @@ contains
     !
   end function subtr_wrap
 
+  !> @brief Increments an index, "wrapping" the result if necessary
   function incr_wrap(istart, ilimit) result(iwrapped)
-! ******************************************************************************
-! incr_wrap -- Increments an index, "wrapping" the result if necessary
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
     ! -- dummy
     integer :: istart, ilimit, iwrapped
-! ------------------------------------------------------------------------------
     !
     ! -- Increment istart. If istart is at ilimit, wrap around to 1. It is
     ! -- assumed (without checking) that istart is not greater than ilimit.
@@ -349,17 +448,11 @@ contains
     !
   end function incr_wrap
 
+  !> @brief Decrements an index, "wrapping" the result if necessary
   function decr_wrap(istart, ilimit) result(iwrapped)
-! ******************************************************************************
-! decr_wrap -- Decrements an index, "wrapping" the result if necessary
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     implicit none
     ! -- dummy
     integer :: istart, ilimit, iwrapped
-! ------------------------------------------------------------------------------
     !
     ! -- Decrement istart. If istart is 1, wrap around to ilimit. It is
     ! -- assumed (without checking) that istart is not less than 1.

--- a/utils/mf5to6/make/makefile
+++ b/utils/mf5to6/make/makefile
@@ -5,10 +5,10 @@ include ./makedefaults
 
 # Define the source file directories
 SOURCEDIR1=../src
-SOURCEDIR2=../src/NWT
+SOURCEDIR2=../src/MF2005
 SOURCEDIR3=../src/LGR
-SOURCEDIR4=../src/Preproc
-SOURCEDIR5=../src/MF2005
+SOURCEDIR4=../src/NWT
+SOURCEDIR5=../src/Preproc
 SOURCEDIR6=../../../src/Utilities/Memory
 SOURCEDIR7=../../../src/Utilities/TimeSeries
 SOURCEDIR8=../../../src/Utilities


### PR DESCRIPTION
Manually merge Alden's work from https://github.com/aprovost-usgs/modflow6/commit/c34ddaae6e5aaf2738136054a2530aeada1eed4d, since there were some conflicts to resolve

- introduce members on `ParticleType` to store global -> local particle coordinate transform info
- introduce routines on `ParticleType` to
  - get global coordinates
  - transform coordinates from global -> local
  - reset coordinates
- call particle transform routines from `Method*` modules
- factor out routines in `TrackData` module to save/reset trackdata

Also some testing updates/improvements