### PR TITLE
ci: update nightly build config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,6 @@ on:
       - master
       - develop
       - ci-diagnose*
-      - PRT
     paths-ignore:
       - '**.md'
       - 'doc/**'
@@ -13,14 +12,9 @@ on:
     branches:
       - master
       - develop
-      - PRT
     paths-ignore:
       - '**.md'
       - 'doc/**'
-  schedule:
-    - cron: '0 2 * * *' # run at 2 AM UTC
-env:
-  LABEL: prt
 jobs:
   lint:
     name: Lint (fprettify)
@@ -44,12 +38,8 @@ jobs:
         run: python .github/common/fortran_format_check.py
 
   build:
-    name: Build and unit test (gfortran 12)
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ ubuntu-22.04, macos-12, windows-2022 ]
+    name: Build (gfortran 12)
+    runs-on: ubuntu-22.04
     defaults:
       run:
         shell: bash -l {0}
@@ -73,33 +63,18 @@ jobs:
           environment-file: environment.yml
           cache-environment: true
           cache-downloads: true
-          init-shell: >-
-            bash
-            powershell
-
-      - name: Update version
-        run: python distribution/update_version.py -v 6.5.0-$LABEL
 
       - name: Meson setup
-        run: meson setup builddir --prefix=$PWD --libdir=bin -Ddebug=false -Dwerror=true
+        run: meson setup builddir -Ddebug=false -Dwerror=true
 
       - name: Meson compile
-        run: meson install -C builddir
+        run: meson compile -C builddir
 
       - name: Meson test
         run: meson test --verbose --no-rebuild -C builddir
 
-      - name: Move code.json
-        run: cp code.json bin/code.json
-
-      - name: Upload binaries
-        uses: actions/upload-artifact@v3
-        with:
-          name: bin-${{ runner.os }}
-          path: bin
-
   smoke_test:
-    name: Smoke testing (gfortran 12)
+    name: Smoke test (gfortran 12)
     runs-on: ubuntu-22.04
     defaults:
       run:
@@ -153,7 +128,7 @@ jobs:
           fi
 
   test_gfortran_latest:
-    name: Integration testing (gfortran 12)
+    name: Test (gfortran 12)
     needs:
       - lint
       - build
@@ -279,7 +254,7 @@ jobs:
         run: pytest -v --durations 0
 
   test_gfortran_previous:
-    name: Integration testing gfortran (${{ matrix.GCC_V }}, ${{ matrix.os }})
+    name: Test gfortran (${{ matrix.GCC_V }}, ${{ matrix.os }})
     needs:
       - lint
       - build
@@ -350,7 +325,7 @@ jobs:
           fi
 
   test_ifort:
-    name: Integration testing (ifort)
+    name: Test (ifort)
     needs:
       - lint
       - build
@@ -617,268 +592,3 @@ jobs:
           markers=$([ "$branch" == "master" ] && echo "$marker and not developmode" || echo "$marker")
           pytest -v -n auto --parallel --durations 0 -m "$markers"
           
-  docs:
-    name: Build documentation
-    needs: build
-    if: github.ref_name == 'PRT'
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-
-      - name: Checkout modflow6
-        uses: actions/checkout@v3
-        with:
-          repository: aprovost-usgs/modflow6
-          path: modflow6
-          ref: PRT
-
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: modflow6/environment.yml
-          cache-environment: true
-          cache-downloads: true
-
-      - name: Checkout usgslatex
-        uses: actions/checkout@v3
-        with:
-          repository: MODFLOW-USGS/usgslatex
-          path: usgslatex
-
-      - name: Install TeX Live
-        run: |
-          sudo apt-get update
-          sudo apt install texlive-latex-extra \
-            texlive-science \
-            texlive-font-utils \
-            texlive-fonts-recommended \
-            texlive-fonts-extra \
-            dos2unix
-
-      - name: Install USGS LaTeX style files and Univers font
-        working-directory: usgslatex/usgsLaTeX
-        run: sudo ./install.sh --all-users
-
-      - name: Download binaries
-        uses: actions/download-artifact@v3
-        with:
-          name: bin-${{ runner.os }}
-          path: modflow6/bin
-
-      - name: Checkout modflow6-examples
-        uses: actions/checkout@v3
-        with:
-          repository: MODFLOW-USGS/modflow6-examples
-          path: modflow6-examples
-
-      - name: Cache modflow6 examples
-        id: cache-examples
-        uses: actions/cache@v3
-        with:
-          path: modflow6-examples/examples
-          key: modflow6-examples-${{ hashFiles('modflow6-examples/scripts/**') }}
-
-      - name: Install extra Python packages
-        if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6-examples/etc
-        run: pip install -r requirements.pip.txt
-
-      - name: Build example models
-        if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6-examples/etc
-        run: python ci_build_files.py
-
-      - name: Update version
-        run: python modflow6/distribution/update_version.py -v 6.5.0-$LABEL
-
-      - name: Build docs
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          # example path below is hard-coded into modflow6/distribution/build_docs.py
-          # once that's fixed, this can be removed
-          mkdir -p modflow6-examples/examples/ex-gwf-twri01
-          
-          # execute permission may not have survived upload/download-artifact actions
-          chmod +x modflow6/bin/mf6
-          chmod +x modflow6/bin/mf5to6
-          chmod +x modflow6/bin/zbud6
-          
-          # build the docs
-          python modflow6/distribution/build_docs.py -d -b modflow6/bin -o docs
-
-      - name: Upload mf6io docs
-        uses: actions/upload-artifact@v3
-        with:
-          name: mf6io
-          path: docs/mf6io.pdf
-      
-      - name: Upload release notes
-        uses: actions/upload-artifact@v3
-        with:
-          name: ReleaseNotes
-          path: docs/ReleaseNotes.pdf
-
-  dist:
-    name: Build distributions
-    needs: docs
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-22.04
-            artifact_name: linux
-          - os: macos-12
-            artifact_name: mac
-          - os: windows-2022
-            artifact_name: win64
-    defaults:
-      run:
-        shell: bash -l {0}
-    steps:
-
-      - name: Checkout modflow6
-        uses: actions/checkout@v3
-        with:
-          repository: aprovost-usgs/modflow6
-          path: modflow6
-          ref: PRT
-
-      - name: Setup Micromamba
-        uses: mamba-org/setup-micromamba@v1
-        with:
-          environment-file: modflow6/environment.yml
-          cache-environment: true
-          cache-downloads: true
-
-      - name: Setup Intel Fortran
-        uses: modflowpy/install-intelfortran-action@v1
-
-      - name: Download binaries
-        uses: actions/download-artifact@v3
-        with:
-          name: bin-${{ runner.os }}
-          path: ${{ matrix.artifact_name }}/bin
-
-      - name: Update FloPy classes
-        working-directory: modflow6/autotest
-        run: python update_flopy.py
-
-      - name: Checkout modflow6-examples
-        uses: actions/checkout@v3
-        with:
-          repository: MODFLOW-USGS/modflow6-examples
-          path: modflow6-examples
-
-      - name: Cache modflow6 examples
-        id: cache-examples
-        uses: actions/cache@v3
-        with:
-          path: modflow6-examples/examples
-          key: modflow6-examples-${{ hashFiles('modflow6-examples/scripts/**') }}
-
-      - name: Install extra Python packages
-        if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6-examples/etc
-        run: pip install -r requirements.pip.txt
-
-      - name: Build example models
-        if: steps.cache-examples.outputs.cache-hit != 'true'
-        working-directory: modflow6-examples/etc
-        run: python ci_build_files.py
-
-      - name: Build distribution
-        run: |
-          # modflow6/distribution/build_dist.py expects the examples repo to exist,
-          # but it's not needed for nightly builds, below can be removed when fixed
-          mkdir -p modflow6-examples
-          
-          # build the dist
-          python modflow6/distribution/build_dist.py -d -o ${{ matrix.artifact_name }}
-
-      - name: Zip distribution
-        if: runner.os != 'Windows'
-        run: zip -j -r ${{ matrix.artifact_name }}.zip ${{ matrix.artifact_name }} -x '*.DS_Store'
-
-      - name: Zip distribution (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: 7z a -tzip ${{ matrix.artifact_name }}.zip ${{ github.workspace }}\${{ matrix.artifact_name }}\bin\* -xr'!libmf6.lib'
-
-      - name: Upload distribution
-        uses: actions/upload-artifact@v3
-        with:
-          name: ${{ matrix.artifact_name }}
-          path: ${{ matrix.artifact_name }}.zip
-
-      - name: Upload mf6io docs
-        if: runner.os == 'Linux'
-        uses: actions/upload-artifact@v3
-        with:
-          name: mf6io
-          path: ${{ matrix.artifact_name }}/doc/mf6io.pdf
-
-  release:
-    name: Create release
-    needs: dist
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        shell: bash
-    if:
-      github.event_name == 'push' || github.event_name == 'schedule'
-    steps:
-
-      - name: Delete Older Releases
-        uses: dev-drprasad/delete-older-releases@v0.2.1
-        with:
-          keep_latest: 30
-          delete_tags: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-        with:
-          path: nightly
-
-      - name: List files in the artifact directory
-        run: ls -l nightly
-
-      - name: Get time
-        uses: josStorer/get-current-time@v2
-        id: current-time
-        with:
-          format: YYYYMMDD
-
-      - name: Show time
-        env:
-          TIME: "${{ steps.current-time.outputs.time }}"
-          F_TIME: "${{ steps.current-time.outputs.formattedTime }}"
-        run: echo $TIME $F_TIME
-
-      - name: Create release
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.current-time.outputs.formattedTime }}
-          name: ${{ steps.current-time.outputs.formattedTime }} nightly build
-          body: "MODFLOW 6 PRT nightly development build, compiled with Intel Fortran."
-          draft: false
-          allowUpdates: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      # remove all but zip and pdf files
-      - name: Prune release assets
-        run: find nightly -type f ! -name '*.zip' ! -name '*.pdf' -delete
-
-      - name: Upload release assets
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: nightly/**
-          tag: ${{ steps.current-time.outputs.formattedTime }}
-          overwrite: true
-          file_glob: true

--- a/.github/workflows/prt.yml
+++ b/.github/workflows/prt.yml
@@ -1,0 +1,101 @@
+name: MODFLOW 6 PRT dev build
+on:
+  push:
+    branches:
+      - master
+      - develop
+      - ci-diagnose*
+      - PRT
+    paths-ignore:
+      - '**.md'
+      - 'doc/**'
+  pull_request:
+    branches:
+      - master
+      - develop
+    paths-ignore:
+      - '**.md'
+      - 'doc/**'
+  schedule:
+    - cron: '0 2 * * *'
+env:
+  LABEL: prt
+jobs:
+  make_dist:
+    name: Make distribution
+    # don't make distribution if triggering event is pull request
+    # if: github.event_name == 'push' || github.event_name == 'schedule'
+    uses: MODFLOW-USGS/modflow6/.github/workflows/release.yml@develop
+    with:
+      approve: false
+      branch: PRT
+      developmode: true
+      full: false
+      linux_version: ubuntu-20.04
+      run_tests: false
+      version: 6.4.2prt
+
+  release:
+    name: Create release
+    needs: make_dist
+    runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash
+    # don't create a release post if triggering event is pull request
+    if: github.event_name == 'push' || github.event_name == 'schedule'
+    steps:
+
+      - name: Delete Older Releases
+        uses: dev-drprasad/delete-older-releases@v0.2.1
+        with:
+          keep_latest: 10
+          delete_tags: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v3
+        with:
+          path: nightly
+
+      - name: List artifacts
+        working-directory: nightly
+        run: |
+          echo "artifacts include:"
+          ls -lR .
+
+      - name: Prune artifacts
+        working-directory: nightly
+        run: |
+          echo "pruning artifacts"
+          for f in mf*/mf*; do mv -- "$f" "$(basename $f)"; done
+          for f in *.zip; do mv -- "$f" "${f##mf*${{ env.LABEL }}_}"; done
+          find mf* -type d -delete
+          rm -rf bin-*
+          rm -rf release_notes
+          echo "release assets include:"
+          ls -lR .
+
+      - name: Get date
+        uses: josStorer/get-current-time@v2
+        id: current-time
+        with:
+          format: YYYYMMDD
+
+      - name: Show time
+        env:
+          TIME: "${{ steps.current-time.outputs.time }}"
+          F_TIME: "${{ steps.current-time.outputs.formattedTime }}"
+        run: echo $TIME $F_TIME
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.current-time.outputs.formattedTime }}
+          name: ${{ steps.current-time.outputs.formattedTime }} PRT development build
+          body: "MODFLOW 6 PRT development build, compiled with Intel Fortran."
+          draft: false
+          allowUpdates: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: "nightly/*.zip,nightly/doc/*.pdf"


### PR DESCRIPTION
Use the `release.yml` reusable workflow recently [introduced to mf6](https://github.com/MODFLOW-USGS/modflow6/pull/1246) for a development PRT build