### PR TITLE
refactor(PRT): multiple

### DIFF
--- a/.github/workflows/prt.yml
+++ b/.github/workflows/prt.yml
@@ -25,7 +25,7 @@ jobs:
   make_dist:
     name: Make distribution
     # don't make distribution if triggering event is pull request
-    # if: github.event_name == 'push' || github.event_name == 'schedule'
+    if: github.event_name == 'push' || github.event_name == 'schedule'
     uses: MODFLOW-USGS/modflow6/.github/workflows/release.yml@develop
     with:
       approve: false

--- a/src/Model/ModelUtilities/TrackData.f90
+++ b/src/Model/ModelUtilities/TrackData.f90
@@ -10,6 +10,8 @@ module TrackDataModule
   private
   public :: TrackDataType
 
+  integer(I4B), parameter, public :: INITIAL_TRACK_SIZE = 1000
+
   character(len=*), parameter, public :: TRACKHEADERS = &
                 'kper,kstp,iprp,irpt,icell,izone,istatus,ireason,&
                 &trelease,t,x,y,z'
@@ -70,6 +72,7 @@ contains
     integer(I4B), intent(in) :: nt
     character(len=*), intent(in) :: mempath
     !
+    print *, 'allocating ', nt, ' slots for track data arrays'
     allocate (character(len=len(mempath)) :: this%mempath)
     ! call mem_allocate(this%mempath, size(mempath), 'TRACKMEMPATH', mempath)
     this%mempath = mempath ! kluge!!!
@@ -152,6 +155,8 @@ contains
     integer(I4B), intent(in), optional :: level
     ! -- local
     integer(I4B) :: ntrack, ntracksize
+    integer(I4B) :: resizefactor, resizethresh
+    real(DP) :: resizefraction
     logical(LGP) :: ladd
     real(DP) :: xmodel, ymodel, zmodel
     !
@@ -167,20 +172,21 @@ contains
     end if
     !
     if (ladd) then
-      ! -- Expand track arrays if needed, shrink if possible.
-      ! -- Expand if we are at capacity. Shrink if less than
-      ! -- 10% capacity is in use.
+      !
+      ! -- Expand track arrays by factor of 10 if at capacity.
+      resizefactor = 10
+      resizethresh = 100
+      resizefraction = 0.01
       ntracksize = size(this%irpt)
-      if ((ntracksize - this%ntrack) < 2) then
-        print *, 'Expanding track arrays'
-        call this%reallocate_arrays(ntracksize * 10, this%mempath)
+      if ((ntracksize - this%ntrack) < 1) then
+        print *, 'Expanding track arrays from ', ntracksize, &
+          ' to ', ntracksize * resizefactor
+        call this%reallocate_arrays(ntracksize * resizefactor, this%mempath)
       end if
-      if ((ntracksize - this%ntrack) > (this%ntrack * 10)) then
-        print *, 'Shrinking track arrays'
-        call this%reallocate_arrays(ntracksize / 10, this%mempath)
-      end if
+      !
       ! -- Get model coordinates
       call particle%get_model_coords(xmodel, ymodel, zmodel)
+      !
       ! -- Add track data
       ntrack = this%ntrack + 1
       this%ntrack = ntrack

--- a/src/Model/ModelUtilities/TrackData.f90
+++ b/src/Model/ModelUtilities/TrackData.f90
@@ -38,8 +38,8 @@ module TrackDataModule
     integer(I4B), dimension(:), pointer, contiguous :: ireason ! reason for datum
     ! ireason can take values:
     !   0: release
-    !   1: cross boundary (cell? subcell? or generic feature? worth distinguishing?)
-    !   2: todo time series
+    !   1: cross spatial boundary (cell? subcell? or generic feature? worth distinguishing?)
+    !   2: cross temporal boundary (time step end)
     !   3: termination
     !   4: inactive
 

--- a/src/Model/ModelUtilities/TrackData.f90
+++ b/src/Model/ModelUtilities/TrackData.f90
@@ -70,6 +70,8 @@ contains
     integer(I4B), intent(in) :: nt
     character(len=*), intent(in) :: mempath
     !
+    allocate (character(len=len(mempath)) :: this%mempath)
+    ! call mem_allocate(this%mempath, size(mempath), 'TRACKMEMPATH', mempath)
     this%mempath = mempath ! kluge!!!
     ! call mem_setptr(mempath, 'TRACKMEMPATH', mempath)
     call mem_allocate(this%kper, nt, 'TRACKKPER', mempath)
@@ -172,11 +174,11 @@ contains
       if ((ntracksize - this%ntrack) < 2) then
         print *, 'Expanding track arrays'
         call this%reallocate_arrays(ntracksize * 10, this%mempath)
-      endif
+      end if
       if ((ntracksize - this%ntrack) > (this%ntrack * 10)) then
         print *, 'Shrinking track arrays'
         call this%reallocate_arrays(ntracksize / 10, this%mempath)
-      endif
+      end if
       ! -- Get model coordinates
       call particle%get_model_coords(xmodel, ymodel, zmodel)
       ! -- Add track data

--- a/src/Model/ModelUtilities/TrackData.f90
+++ b/src/Model/ModelUtilities/TrackData.f90
@@ -179,8 +179,8 @@ contains
       resizefraction = 0.01
       ntracksize = size(this%irpt)
       if ((ntracksize - this%ntrack) < 1) then
-        print *, 'Expanding track arrays from ', ntracksize, &
-          ' to ', ntracksize * resizefactor
+        ! print *, 'Expanding track arrays from ', ntracksize, &
+        !   ' to ', ntracksize * resizefactor
         call this%reallocate_arrays(ntracksize * resizefactor, this%mempath)
       end if
       !

--- a/src/Model/ModelUtilities/TrackData.f90
+++ b/src/Model/ModelUtilities/TrackData.f90
@@ -27,6 +27,7 @@ module TrackDataModule
   !   - trelease: particle release time (retrieved from partlist)
   type :: TrackDataType
     ! integer arrays
+    character(len=:), pointer :: mempath => null() ! memory path of track data
     integer(I4B), pointer :: ntrack => null() ! total count of track data
     integer(I4B), dimension(:), pointer, contiguous :: kper ! stress period
     integer(I4B), dimension(:), pointer, contiguous :: kstp ! time step
@@ -51,12 +52,92 @@ module TrackDataModule
     real(DP), dimension(:), pointer, contiguous :: z ! current z coordinate
 
   contains
+    procedure, public :: allocate_arrays
+    procedure, public :: deallocate_arrays
+    procedure, public :: reallocate_arrays
     procedure, public :: add_track_data
     procedure, public :: reset_track_data
     procedure, public :: save_track_data
   end type TrackDataType
 
 contains
+
+  subroutine allocate_arrays(this, nt, mempath)
+    ! -- modules
+    use MemoryManagerModule, only: mem_allocate
+    ! -- dummy
+    class(TrackDataType), intent(inout) :: this
+    integer(I4B), intent(in) :: nt
+    character(len=*), intent(in) :: mempath
+    !
+    this%mempath = mempath ! kluge!!!
+    ! call mem_setptr(mempath, 'TRACKMEMPATH', mempath)
+    call mem_allocate(this%kper, nt, 'TRACKKPER', mempath)
+    call mem_allocate(this%kstp, nt, 'TRACKKSTP', mempath)
+    call mem_allocate(this%iprp, nt, 'TRACKIPRP', mempath)
+    call mem_allocate(this%irpt, nt, 'TRACKIRPT', mempath)
+    call mem_allocate(this%icell, nt, 'TRACKICELL', mempath)
+    call mem_allocate(this%izone, nt, 'TRACKIZONE', mempath)
+    call mem_allocate(this%istatus, nt, 'TRACKISTATUS', mempath)
+    call mem_allocate(this%ireason, nt, 'TRACKIREASON', mempath)
+    call mem_allocate(this%trelease, nt, 'TRACKTRELEASE', mempath)
+    call mem_allocate(this%t, nt, 'TRACKT', mempath)
+    call mem_allocate(this%x, nt, 'TRACKX', mempath)
+    call mem_allocate(this%y, nt, 'TRACKY', mempath)
+    call mem_allocate(this%z, nt, 'TRACKZ', mempath)
+    !
+    return
+  end subroutine allocate_arrays
+
+  subroutine deallocate_arrays(this, mempath)
+    ! -- modules
+    use MemoryManagerModule, only: mem_deallocate
+    ! -- dummy
+    class(TrackDataType), intent(inout) :: this
+    character(len=*), intent(in) :: mempath
+    !
+    deallocate (this%mempath) ! kluge!!!
+    call mem_deallocate(this%kper)
+    call mem_deallocate(this%kstp)
+    call mem_deallocate(this%iprp)
+    call mem_deallocate(this%irpt)
+    call mem_deallocate(this%icell)
+    call mem_deallocate(this%izone)
+    call mem_deallocate(this%istatus)
+    call mem_deallocate(this%ireason)
+    call mem_deallocate(this%trelease)
+    call mem_deallocate(this%t)
+    call mem_deallocate(this%x)
+    call mem_deallocate(this%y)
+    call mem_deallocate(this%z)
+    !
+    return
+  end subroutine deallocate_arrays
+
+  subroutine reallocate_arrays(this, nt, mempath)
+    ! -- modules
+    use MemoryManagerModule, only: mem_reallocate
+    ! -- dummy
+    class(TrackDataType), intent(inout) :: this
+    integer(I4B), intent(in) :: nt
+    character(len=*), intent(in) :: mempath
+    !
+    call mem_reallocate(this%kper, nt, 'TRACKKPER', mempath)
+    call mem_reallocate(this%kstp, nt, 'TRACKKSTP', mempath)
+    call mem_reallocate(this%iprp, nt, 'TRACKIPRP', mempath)
+    call mem_reallocate(this%irpt, nt, 'TRACKIRPT', mempath)
+    call mem_reallocate(this%icell, nt, 'TRACKICELL', mempath)
+    call mem_reallocate(this%izone, nt, 'TRACKIZONE', mempath)
+    call mem_reallocate(this%istatus, nt, 'TRACKISTATUS', mempath)
+    call mem_reallocate(this%ireason, nt, 'TRACKIREASON', mempath)
+    call mem_reallocate(this%trelease, nt, 'TRACKTRELEASE', mempath)
+    call mem_reallocate(this%t, nt, 'TRACKT', mempath)
+    call mem_reallocate(this%x, nt, 'TRACKX', mempath)
+    call mem_reallocate(this%y, nt, 'TRACKY', mempath)
+    call mem_reallocate(this%z, nt, 'TRACKZ', mempath)
+    !
+    return
+  end subroutine reallocate_arrays
 
   !> @brief Add track data from a particle
   subroutine add_track_data(this, particle, reason, level)
@@ -68,7 +149,7 @@ contains
     integer(I4B), intent(in) :: reason
     integer(I4B), intent(in), optional :: level
     ! -- local
-    integer(I4B) :: ntrack
+    integer(I4B) :: ntrack, ntracksize
     logical(LGP) :: ladd
     real(DP) :: xmodel, ymodel, zmodel
     !
@@ -84,6 +165,18 @@ contains
     end if
     !
     if (ladd) then
+      ! -- Expand track arrays if needed, shrink if possible.
+      ! -- Expand if we are at capacity. Shrink if less than
+      ! -- 10% capacity is in use.
+      ntracksize = size(this%irpt)
+      if ((ntracksize - this%ntrack) < 2) then
+        print *, 'Expanding track arrays'
+        call this%reallocate_arrays(ntracksize * 10, this%mempath)
+      endif
+      if ((ntracksize - this%ntrack) > (this%ntrack * 10)) then
+        print *, 'Shrinking track arrays'
+        call this%reallocate_arrays(ntracksize / 10, this%mempath)
+      endif
       ! -- Get model coordinates
       call particle%get_model_coords(xmodel, ymodel, zmodel)
       ! -- Add track data

--- a/src/Model/ParticleTracking/prt1.f90
+++ b/src/Model/ParticleTracking/prt1.f90
@@ -1129,19 +1129,7 @@ contains
     call mem_deallocate(this%massstoold)
     call mem_deallocate(this%ratesto)
     call mem_deallocate(this%itrack)
-    call mem_deallocate(this%trackdata%kper)
-    call mem_deallocate(this%trackdata%kstp)
-    call mem_deallocate(this%trackdata%iprp)
-    call mem_deallocate(this%trackdata%irpt)
-    call mem_deallocate(this%trackdata%icell)
-    call mem_deallocate(this%trackdata%izone)
-    call mem_deallocate(this%trackdata%istatus)
-    call mem_deallocate(this%trackdata%ireason)
-    call mem_deallocate(this%trackdata%trelease)
-    call mem_deallocate(this%trackdata%t)
-    call mem_deallocate(this%trackdata%x)
-    call mem_deallocate(this%trackdata%y)
-    call mem_deallocate(this%trackdata%z)
+    call this%trackdata%deallocate_arrays(this%memoryPath)
     !
     ! -- Track data object
     deallocate (this%trackdata)
@@ -1235,38 +1223,13 @@ contains
     ! -- simulate stationary particles). After the
     ! -- initial allocation, reallocate as needed,
     ! -- incrementing logarithmically??
-    ! ntrackmx = size(this%partlist%irpt) * 2
-    ntrackmx = 1000000
-
+    ntrackmx = size(this%partlist%irpt) * 2
+    ! ntrackmx = 1000000
     call mem_allocate(this%itrack, this%nprp + 1, &
                       'ITRACK', this%memorypath)
-    call mem_allocate(this%trackdata%kper, ntrackmx, &
-                      'TRACKKPER', this%memorypath)
-    call mem_allocate(this%trackdata%kstp, ntrackmx, &
-                      'TRACKKSTP', this%memorypath)
-    call mem_allocate(this%trackdata%iprp, ntrackmx, &
-                      'TRACKIPRP', this%memorypath)
-    call mem_allocate(this%trackdata%irpt, ntrackmx, &
-                      'TRACKIRPT', this%memorypath)
-    call mem_allocate(this%trackdata%icell, ntrackmx, &
-                      'TRACKICELL', this%memorypath)
-    call mem_allocate(this%trackdata%izone, ntrackmx, &
-                      'TRACKIZONE', this%memorypath)
-    call mem_allocate(this%trackdata%istatus, ntrackmx, &
-                      'TRACKISTATUS', this%memorypath)
-    call mem_allocate(this%trackdata%ireason, ntrackmx, &
-                      'TRACKIREASON', this%memorypath)
-    call mem_allocate(this%trackdata%trelease, ntrackmx, &
-                      'TRACKTRELEASE', this%memorypath)
-    call mem_allocate(this%trackdata%t, ntrackmx, &
-                      'TRACKT', this%memorypath)
-    call mem_allocate(this%trackdata%x, ntrackmx, &
-                      'TRACKX', this%memorypath)
-    call mem_allocate(this%trackdata%y, ntrackmx, &
-                      'TRACKY', this%memorypath)
-    call mem_allocate(this%trackdata%z, ntrackmx, &
-                      'TRACKZ', this%memorypath)
+    call this%trackdata%allocate_arrays(ntrackmx, this%memoryPath)
     !
+    ! -- allocate arrays for storage
     call mem_allocate(this%masssto, this%dis%nodes, &
                       'MASSSTO', this%memoryPath)
     call mem_allocate(this%massstoold, this%dis%nodes, &
@@ -1429,7 +1392,7 @@ contains
     ! -- dummy variables
     class(PrtModelType) :: this
     ! -- local variables
-    integer(I4B) :: np, ip
+    integer(I4B) :: np, ip, ntracksize
     class(BndType), pointer :: packobj
     type(ParticleType), pointer :: particle
     class(MethodType), pointer :: method
@@ -1454,6 +1417,15 @@ contains
         !
         ! -- Loop over particles in package
         do np = 1, packobj%npart
+          !
+          ! -- Expand track arrays if needed, shrink if possible.
+          ! -- Expand if we are at capacity. Shrink if less than
+          ! -- 10% capacity is in use.
+          ! ntracksize = size(this%trackdata%irpt)
+          ! if ((ntracksize - this%trackdata%ntrack) < 2) &
+          !   call this%trackdata%reallocate_arrays(ntracksize * 10, this%memoryPath)
+          ! if ((ntracksize - this%trackdata%ntrack) > (this%trackdata%ntrack * 10)) &
+          !   call this%trackdata%reallocate_arrays(ntracksize / 10, this%memoryPath)
           !
           ! -- If particle inactive, record (unchanged) location in track data and skip tracking
           ! kluge note: temporarily commented out recording of inactive particle data; want it, maybe as an option???

--- a/src/Model/ParticleTracking/prt1.f90
+++ b/src/Model/ParticleTracking/prt1.f90
@@ -30,7 +30,7 @@ module PrtModule
   use ParticleModule ! kluge
   use MethodModule
   use GlobalDataModule
-  use TrackDataModule, only: TrackDataType ! kluge?
+  use TrackDataModule, only: TrackDataType, INITIAL_TRACK_SIZE ! kluge?
   use SimModule, only: count_errors, store_error, store_error_filename
 
   implicit none
@@ -1214,34 +1214,25 @@ contains
     ! -- Allocate arrays in TrackingModelType
     call this%TrackingModelType%allocate_arrays()
     !
-    ! -- count particles in all PRPs
-    do ip = 1, this%bndlist%Count()
-      packobj => GetBndFromList(this%bndlist, ip)
-      select type (packobj)
-      type is (PrtPrpType) ! kluge
-        npart = npart + packobj%partlist%count()
-      end select
-    end do
-    !
-    ! -- Allocate two positions for each particle
-    ! -- to begin with, start & end of time step.
-    ! -- This wastes a slot for any particle that
-    ! -- doesn't move. Oh well.
-    ntrackmx = npart * 2
-    ! ntrackmx = 1000000
+    ! -- allocate track index
     call mem_allocate(this%itrack, this%nprp + 1, &
-                      'ITRACK', this%memorypath)
+                      'ITRACK', this%memoryPath)
+    !
+    ! -- Allocate some initial breathing room for track data.
+    ! -- Depending how many particles the model has, and how
+    ! -- quickly they move, this may be a huge underestimate,
+    ! -- but we expand by a factor of 10 each time we run out
+    ! -- of space, so resizing should be needed infrequently.
+    ntrackmx = INITIAL_TRACK_SIZE
     call this%trackdata%allocate_arrays(ntrackmx, this%memoryPath)
     !
-    ! -- allocate arrays for storage
+    ! -- allocate and initialize arrays for mass storage
     call mem_allocate(this%masssto, this%dis%nodes, &
                       'MASSSTO', this%memoryPath)
     call mem_allocate(this%massstoold, this%dis%nodes, &
                       'MASSSTOOLD', this%memoryPath)
     call mem_allocate(this%ratesto, this%dis%nodes, &
                       'RATESTO', this%memoryPath)
-    !
-    ! -- initialize
     do n = 1, this%dis%nodes
       this%masssto(n) = DZERO
       this%massstoold(n) = DZERO
@@ -1396,7 +1387,7 @@ contains
     ! -- dummy variables
     class(PrtModelType) :: this
     ! -- local variables
-    integer(I4B) :: np, ip
+    integer(I4B) :: np, ip, npart
     class(BndType), pointer :: packobj
     type(ParticleType), pointer :: particle
     class(MethodType), pointer :: method
@@ -1404,10 +1395,31 @@ contains
     logical(LGP) :: limited
     integer(I4B) :: iprp
     logical(LGP) :: save_inactive = .false.
+    integer(I4B) :: ntracksize, resizefactor, resizethresh, shrinksize
+    real(DP) :: resizefraction
     !
     call create_particle(particle) ! kluge note: elsewhere???
     !
     call this%trackdata%reset_track_data()
+    !
+    ! -- Shrink track arrays by a factor of resizefactor
+    ! -- if less than (resizefraction * 100)% is in use.
+    ! -- Never shrink below the intial trackdata size
+    ! -- purpose of resizethresh is to prevent shrinking
+    ! -- when the track array size is small. Also, never
+    ! -- shrink below minimum size (particle count) * 2.
+    resizefactor = 10
+    resizethresh = INITIAL_TRACK_SIZE
+    resizefraction = 0.01
+    ntracksize = size(this%trackdata%irpt)
+    if (this%trackdata%ntrack < (ntracksize * resizefraction) .and. &
+        ntracksize > resizethresh) then
+      shrinksize = ntracksize / resizefactor
+      if (shrinksize < resizethresh) shrinksize = resizethresh
+      print *, 'Shrinking track arrays from ', ntracksize, &
+        ' to ', shrinksize
+      call this%trackdata%reallocate_arrays(shrinksize, this%memoryPath)
+    end if
     !
     ! -- Loop over PRP packages
     iprp = 0
@@ -1421,15 +1433,6 @@ contains
         !
         ! -- Loop over particles in package
         do np = 1, packobj%npart
-          !
-          ! -- Expand track arrays if needed, shrink if possible.
-          ! -- Expand if we are at capacity. Shrink if less than
-          ! -- 10% capacity is in use.
-          ! ntracksize = size(this%trackdata%irpt)
-          ! if ((ntracksize - this%trackdata%ntrack) < 2) &
-          !   call this%trackdata%reallocate_arrays(ntracksize * 10, this%memoryPath)
-          ! if ((ntracksize - this%trackdata%ntrack) > (this%trackdata%ntrack * 10)) &
-          !   call this%trackdata%reallocate_arrays(ntracksize / 10, this%memoryPath)
           !
           ! -- If particle inactive, record (unchanged) location in track data and skip tracking
           ! kluge note: temporarily commented out recording of inactive particle data; want it, maybe as an option???

--- a/src/Model/ParticleTracking/prt1.f90
+++ b/src/Model/ParticleTracking/prt1.f90
@@ -1226,8 +1226,17 @@ contains
     ! -- Allocate arrays in TrackingModelType
     call this%TrackingModelType%allocate_arrays()
     !
-
-    ntrackmx = 1000000 ! kluge hardwire (todo dynamically resize)
+    ! -- Allocate two positions for each particle,
+    ! -- start and end of time step. The particles
+    ! -- may not move, but doubling the memory hit
+    ! -- in that case to twice the particle number
+    ! -- does not seem excessive, and it is likely
+    ! -- not a commonly encountered situation (why
+    ! -- simulate stationary particles). After the
+    ! -- initial allocation, reallocate as needed,
+    ! -- incrementing logarithmically as needed.
+    ! ntrackmx = size(this%partlist%irpt) * 2
+    ntrackmx = 1000000
 
     call mem_allocate(this%itrack, this%nprp + 1, &
                       'ITRACK', this%memorypath)
@@ -1446,36 +1455,18 @@ contains
         ! -- Loop over particles in package
         do np = 1, packobj%npart
           !
-          ! -- Skip particle if inactive
-          ! if (packobj%partlist%istatus(np).ne.1) cycle
-          ! -- If particle inactive, record (unchanged) location in track data
-          ! -- and skip tracking
+          ! -- If particle inactive, record (unchanged) location in track data and skip tracking
           ! kluge note: temporarily commented out recording of inactive particle data; want it, maybe as an option???
           if (packobj%partlist%istatus(np) .ne. 1 .and. save_inactive) then
-            call this%trackdata%add_track_data(particle, reason=3) ! reason=4 is inactive
+            call this%trackdata%add_track_data(particle, reason=4) ! reason=4 is inactive
             cycle
           end if
           !
+          ! -- Reset the particle's coordinate transformation
           call particle%reset_transf()
 
-          ! kluge note: make subroutine to set particle props?
-          particle%iprp = iprp
-          particle%irpt = np ! kluge note: necessary to reset this here?
-          particle%istopweaksink = packobj%partlist%istopweaksink(np)
-          particle%istopzone = packobj%partlist%istopzone(np)
-          particle%iTrackingDomain(levelMin:levelMax) = &
-            packobj%partlist%iTrackingDomain(np, levelMin:levelMax)
-          particle%iTrackingDomain(1) = this%id ! kluge note: set this elsewhere???
-          particle%iTrackingDomainBoundary(levelMin:levelMax) = &
-            packobj%partlist%iTrackingDomainBoundary(np, levelMin:levelMax)
-          particle%izone = 1 ! particles start in zone 1 (active domain)
-          particle%istatus = -1
-          particle%x = packobj%partlist%x(np)
-          particle%y = packobj%partlist%y(np)
-          particle%z = packobj%partlist%z(np)
-          particle%trelease = packobj%partlist%trelease(np)
-          particle%tstop = packobj%partlist%tstop(np)
-          particle%ttrack = packobj%partlist%ttrack(np)
+          ! -- Update particle properties from particle list
+          call particle%update_from_list(packobj%partlist, this%id, iprp, np)
 
           ! if (particle%iTrackingDomain(2).eq.0) then
           ! if (particle%iTrackingDomain(2).lt.0) then
@@ -1513,21 +1504,8 @@ contains
           ! -- Apply the tracking method
           call method%apply(particle, tmax)
           !
-          packobj%partlist%irpt(np) = particle%irpt ! kluge note: necessary to (re)set this here?
-          packobj%partlist%iTrackingDomain( &
-            np, &
-            levelMin:levelMax) = &
-            particle%iTrackingDomain(levelMin:levelMax)
-          packobj%partlist%iTrackingDomainBoundary( &
-            np, &
-            levelMin:levelMax) = &
-            particle%iTrackingDomainBoundary(levelMin:levelMax)
-          packobj%partlist%izone(np) = particle%izone
-          packobj%partlist%istatus(np) = particle%istatus
-          packobj%partlist%x(np) = particle%x ! kluge note: make subroutine to update particle in list???
-          packobj%partlist%y(np) = particle%y
-          packobj%partlist%z(np) = particle%z
-          packobj%partlist%ttrack(np) = particle%ttrack
+          ! -- Update particle in list
+          call packobj%partlist%update_from_particle(particle, np)
           !
         end do
       end select

--- a/src/Model/ParticleTracking/prt1.f90
+++ b/src/Model/ParticleTracking/prt1.f90
@@ -1208,22 +1208,26 @@ contains
     ! use ConstantsModule, only: DZERO
     use MemoryManagerModule, only: mem_allocate
     class(PrtModelType) :: this
-    integer(I4B) :: n
-    integer(I4B) :: ntrackmx
+    integer(I4B) :: n, ip, ntrackmx, npart
+    class(BndType), pointer :: packobj
     !
     ! -- Allocate arrays in TrackingModelType
     call this%TrackingModelType%allocate_arrays()
     !
-    ! -- Allocate two positions for each particle,
-    ! -- start and end of time step. The particles
-    ! -- may not move, but doubling the memory hit
-    ! -- in that case to twice the particle number
-    ! -- does not seem excessive, and it is likely
-    ! -- not a commonly encountered situation (why
-    ! -- simulate stationary particles). After the
-    ! -- initial allocation, reallocate as needed,
-    ! -- incrementing logarithmically??
-    ntrackmx = size(this%partlist%irpt) * 2
+    ! -- count particles in all PRPs
+    do ip = 1, this%bndlist%Count()
+      packobj => GetBndFromList(this%bndlist, ip)
+      select type (packobj)
+      type is (PrtPrpType) ! kluge
+        npart = npart + packobj%partlist%count()
+      end select
+    end do
+    !
+    ! -- Allocate two positions for each particle
+    ! -- to begin with, start & end of time step.
+    ! -- This wastes a slot for any particle that
+    ! -- doesn't move. Oh well.
+    ntrackmx = npart * 2
     ! ntrackmx = 1000000
     call mem_allocate(this%itrack, this%nprp + 1, &
                       'ITRACK', this%memorypath)

--- a/src/Model/ParticleTracking/prt1.f90
+++ b/src/Model/ParticleTracking/prt1.f90
@@ -1234,7 +1234,7 @@ contains
     ! -- not a commonly encountered situation (why
     ! -- simulate stationary particles). After the
     ! -- initial allocation, reallocate as needed,
-    ! -- incrementing logarithmically as needed.
+    ! -- incrementing logarithmically??
     ! ntrackmx = size(this%partlist%irpt) * 2
     ntrackmx = 1000000
 

--- a/src/Model/ParticleTracking/prt1.f90
+++ b/src/Model/ParticleTracking/prt1.f90
@@ -1208,8 +1208,7 @@ contains
     ! use ConstantsModule, only: DZERO
     use MemoryManagerModule, only: mem_allocate
     class(PrtModelType) :: this
-    integer(I4B) :: n, ip, ntrackmx, npart
-    class(BndType), pointer :: packobj
+    integer(I4B) :: n, ntrackmx
     !
     ! -- Allocate arrays in TrackingModelType
     call this%TrackingModelType%allocate_arrays()
@@ -1387,7 +1386,7 @@ contains
     ! -- dummy variables
     class(PrtModelType) :: this
     ! -- local variables
-    integer(I4B) :: np, ip, npart
+    integer(I4B) :: np, ip
     class(BndType), pointer :: packobj
     type(ParticleType), pointer :: particle
     class(MethodType), pointer :: method
@@ -1416,8 +1415,8 @@ contains
         ntracksize > resizethresh) then
       shrinksize = ntracksize / resizefactor
       if (shrinksize < resizethresh) shrinksize = resizethresh
-      print *, 'Shrinking track arrays from ', ntracksize, &
-        ' to ', shrinksize
+      ! print *, 'Shrinking track arrays from ', ntracksize, &
+      !   ' to ', shrinksize
       call this%trackdata%reallocate_arrays(shrinksize, this%memoryPath)
     end if
     !

--- a/src/Model/ParticleTracking/prt1.f90
+++ b/src/Model/ParticleTracking/prt1.f90
@@ -1396,7 +1396,7 @@ contains
     ! -- dummy variables
     class(PrtModelType) :: this
     ! -- local variables
-    integer(I4B) :: np, ip, ntracksize
+    integer(I4B) :: np, ip
     class(BndType), pointer :: packobj
     type(ParticleType), pointer :: particle
     class(MethodType), pointer :: method

--- a/src/Model/ParticleTracking/prt1prp1.f90
+++ b/src/Model/ParticleTracking/prt1prp1.f90
@@ -420,6 +420,13 @@ contains
     !
     ! -- Do the release, if there is one
     if (isRelease) then
+
+      ! resize particle arrays if needed
+      if ((this%npart + this%nreleasepts) > this%npartmax) then
+        this%npartmax = this%npartmax + this%nreleasepts
+        call this%partlist%reallocate_arrays(this%npartmax, this%memoryPath)
+      end if
+
       do nps = 1, this%nreleasepts
         ic = this%noder(nps) ! reduced node number (cell ID)
         ! -- If drape option activated, release particle in highest active

--- a/src/Model/ParticleTracking/prt1prp1.f90
+++ b/src/Model/ParticleTracking/prt1prp1.f90
@@ -478,6 +478,7 @@ contains
         this%partlist%ttrack(np) = trelease
         this%partlist%istopweaksink(np) = this%istopweaksink
         this%partlist%istopzone(np) = this%istopzone
+        this%partlist%izone = 1 ! particles start in zone 1 (active domain)
         this%partlist%istatus(np) = 1
         this%partlist%irpt(np) = nps
         this%partlist%iTrackingDomain(np, 0) = 0 ! kluge???

--- a/src/Model/ParticleTracking/prt1prp1.f90
+++ b/src/Model/ParticleTracking/prt1prp1.f90
@@ -190,25 +190,12 @@ contains
     ! call mem_deallocate(this%retfactor)
     ! call mem_deallocate(this%izone)
     !
-    deallocate (this%partlist%irpt)
-    deallocate (this%partlist%iprp)
-    deallocate (this%partlist%istopweaksink)
-    deallocate (this%partlist%istopzone)
-    deallocate (this%partlist%iTrackingDomain)
-    deallocate (this%partlist%iTrackingDomainBoundary)
-    deallocate (this%partlist%izone)
-    deallocate (this%partlist%istatus)
-    deallocate (this%partlist%x) ! kluge note: use mem_deallocate for these arrays
-    deallocate (this%partlist%y)
-    deallocate (this%partlist%z)
-    deallocate (this%partlist%trelease)
-    deallocate (this%partlist%tstop)
-    deallocate (this%partlist%ttrack)
-    !
+    ! -- deallocate particle list
+    call this%partlist%deallocate_arrays(this%memoryPath)
     deallocate (this%partlist) ! kluge note: structure of arrays
     call mem_deallocate(this%massrls)
     !
-    ! -- allocatable array (not pointer)
+    ! -- deallocate step release array
     if (allocated(this%kstp_list_rls)) deallocate (this%kstp_list_rls)
     !
     ! -- return
@@ -268,26 +255,14 @@ contains
     ! call mem_allocate(this%retfactor, this%dis%nodes, 'RETFACTOR',            &
     !                   this%memoryPath)
     ! call mem_allocate(this%izone, this%dis%nodes, 'IZONE', this%memoryPath)
-    allocate (this%partlist) ! kluge note: structure of arrays
-    allocate (this%partlist%irpt(this%npartmax))
-    allocate (this%partlist%iprp(this%npartmax))
-    ! kluge note: ditch crazy dims
-    allocate (this%partlist%iTrackingDomain(this%npartmax, &
-                                            levelMin:levelMax))
-    ! kluge note: ditch crazy dims
-    allocate (this%partlist%iTrackingDomainBoundary(this%npartmax, &
-                                                    levelMin:levelMax))
-    allocate (this%partlist%izone(this%npartmax))
-    allocate (this%partlist%istatus(this%npartmax))
-    allocate (this%partlist%x(this%npartmax)) ! kluge note: nprtmax is the initial max dimension
-    allocate (this%partlist%y(this%npartmax)) ! kluge note: use mem_allocate for these arrays
-    allocate (this%partlist%z(this%npartmax))
-    allocate (this%partlist%trelease(this%npartmax))
-    allocate (this%partlist%tstop(this%npartmax))
-    allocate (this%partlist%ttrack(this%npartmax))
-    allocate (this%partlist%istopweaksink(this%npartmax))
-    allocate (this%partlist%istopzone(this%npartmax))
 
+    ! -- Allocate particle list
+    allocate (this%partlist) ! kluge note: structure of arrays
+    call this%partlist%allocate_arrays(this%npartmax, &
+                                       levelMin, levelMax, &
+                                       this%memoryPath)
+    !
+    ! -- Allocate mass release array
     call mem_allocate(this%massrls, this%nreleasepts, 'MASSRLS', this%memoryPath)
     !
     ! -- Intialize
@@ -455,7 +430,9 @@ contains
             ! -- Search for highest active cell
             call this%dis%highest_active(ic, this%ibound)
             ! -- If returned cell is inactive, do not release particle
-            if (this%ibound(ic) == 0) cycle ! kluge note: somehow record for the user that a particle was scheduled but not released?
+            ! kluge note: somehow record for the user that a particle was scheduled but not released?
+            ! another ireason code? record single datum for release into inactive cell?
+            if (this%ibound(ic) == 0) cycle
           end if
         end if
         np = this%npart + 1 ! particle index

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -49,10 +49,11 @@ module ParticleModule
 
   contains
     procedure, public :: destroy => destroy_particle ! destructor for the particle
-    procedure, public :: set_transf
-    procedure, public :: reset_transf
-    procedure, public :: transf_coords
     procedure, public :: get_model_coords
+    procedure, public :: reset_transf
+    procedure, public :: set_transf
+    procedure, public :: transf_coords
+    procedure, public :: update_from_list
   end type ParticleType
 
   ! -- Define the particle list type (ParticleListType)  ! kluge note: use separate module???
@@ -81,6 +82,8 @@ module ParticleModule
     real(DP), allocatable, public :: tstop(:) ! particle stop time
     real(DP), allocatable, public :: ttrack(:) ! time to which particle has been tracked
 
+  contains
+    procedure, public :: update_from_particle
   end type ParticleListType
 
 contains
@@ -105,6 +108,59 @@ contains
     deallocate (this%iTrackingDomainBoundary)
     return
   end subroutine destroy_particle
+
+  subroutine update_from_list(this, partlist, im, iprp, irpt)
+    ! -- dummy
+    class(ParticleType), intent(inout) :: this
+    type(ParticleListType), intent(in) :: partlist
+    integer(I4B), intent(in) :: im ! model ID
+    integer(I4B), intent(in) :: iprp ! particle release package ID
+    integer(I4B), intent(in) :: irpt ! particle release point ID
+    !
+    this%iprp = iprp
+    this%irpt = irpt ! kluge note: necessary to reset this here?
+    this%istopweaksink = partlist%istopweaksink(irpt)
+    this%istopzone = partlist%istopzone(irpt)
+    this%iTrackingDomain(levelMin:levelMax) = &
+      partlist%iTrackingDomain(irpt, levelMin:levelMax)
+    this%iTrackingDomain(1) = im
+    this%iTrackingDomainBoundary(levelMin:levelMax) = &
+      partlist%iTrackingDomainBoundary(irpt, levelMin:levelMax)
+    this%istatus = -1 ! need to reset this to -1 every timestep (for solution to proceed)
+    this%x = partlist%x(irpt)
+    this%y = partlist%y(irpt)
+    this%z = partlist%z(irpt)
+    this%trelease = partlist%trelease(irpt)
+    this%tstop = partlist%tstop(irpt)
+    this%ttrack = partlist%ttrack(irpt)
+    !
+    return
+  end subroutine update_from_list
+
+  !> @brief Update particle list from particle
+  subroutine update_from_particle(this, particle, np)
+    ! -- dummy
+    class(ParticleListType), intent(inout) :: this
+    type(ParticleType), intent(in) :: particle
+    integer(I4B), intent(in) :: np
+    !
+    this%iTrackingDomain( &
+      np, &
+      levelMin:levelMax) = &
+      particle%iTrackingDomain(levelMin:levelMax)
+    this%iTrackingDomainBoundary( &
+      np, &
+      levelMin:levelMax) = &
+      particle%iTrackingDomainBoundary(levelMin:levelMax)
+    this%izone(np) = particle%izone
+    this%istatus(np) = particle%istatus
+    this%x(np) = particle%x
+    this%y(np) = particle%y
+    this%z(np) = particle%z
+    this%ttrack(np) = particle%ttrack
+    !
+    return
+  end subroutine update_from_particle
 
   !> @brief Directly set transformation from model coordinates
   !! to particle's local coordinates

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -83,7 +83,7 @@ module ParticleModule
     real(DP), dimension(:), pointer, contiguous :: ttrack ! time to which particle has been tracked
 
   contains
-    procedure, public :: count
+    procedure, public :: Count
     procedure, public :: allocate_arrays
     procedure, public :: deallocate_arrays
     procedure, public :: reallocate_arrays
@@ -92,9 +92,9 @@ module ParticleModule
 
 contains
 
-  pure integer function count(this)
+  pure integer(I4B) function Count(this) result(c)
     class(ParticleListType), intent(in) :: this
-    count = size(this%irpt)
+    c = size(this%irpt)
   end function
 
   !> @brief Create a new particle

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -61,28 +61,30 @@ module ParticleModule
 
     ! provenance/metadata
     ! integer, public :: imodel ! index of model to which the particle currently belongs
-    integer(I4B), allocatable, public :: irpt(:) !< release point number
-    integer(I4B), allocatable, public :: iprp(:) ! particle release point number (index)
+    integer(I4B), dimension(:), pointer, contiguous :: irpt !< release point number
+    integer(I4B), dimension(:), pointer, contiguous :: iprp ! particle release point number (index)
 
     ! stopping criteria
-    integer(I4B), allocatable, public :: istopweaksink(:) !< weak sink option: 0 = do not stop, 1 = stop
-    integer(I4B), allocatable, public :: istopzone(:) !< stop zone number
+    integer(I4B), dimension(:), pointer, contiguous :: istopweaksink !< weak sink option: 0 = do not stop, 1 = stop
+    integer(I4B), dimension(:), pointer, contiguous :: istopzone !< stop zone number
 
     ! tracking domain
-    integer(I4B), allocatable, public :: iTrackingDomain(:, :) ! array of indices for domains in the tracking domain hierarchy
-    integer(I4B), allocatable, public :: iTrackingDomainBoundary(:, :) ! array of indices for tracking domain boundaries
+    integer(I4B), dimension(:, :), pointer, contiguous :: iTrackingDomain ! array of indices for domains in the tracking domain hierarchy
+    integer(I4B), dimension(:, :), pointer, contiguous :: iTrackingDomainBoundary ! array of indices for tracking domain boundaries
 
     ! track data
-    integer(I4B), allocatable, public :: izone(:) !< current zone number
-    integer(I4B), allocatable, public :: istatus(:) !< particle status
-    real(DP), allocatable, public :: x(:) ! model x coord of particle
-    real(DP), allocatable, public :: y(:) ! model y coord of particle
-    real(DP), allocatable, public :: z(:) ! model z coord of particle
-    real(DP), allocatable, public :: trelease(:) ! particle release time
-    real(DP), allocatable, public :: tstop(:) ! particle stop time
-    real(DP), allocatable, public :: ttrack(:) ! time to which particle has been tracked
+    integer(I4B), dimension(:), pointer, contiguous :: izone !< current zone number
+    integer(I4B), dimension(:), pointer, contiguous :: istatus !< particle status
+    real(DP), dimension(:), pointer, contiguous :: x ! model x coord of particle
+    real(DP), dimension(:), pointer, contiguous :: y ! model y coord of particle
+    real(DP), dimension(:), pointer, contiguous :: z ! model z coord of particle
+    real(DP), dimension(:), pointer, contiguous :: trelease ! particle release time
+    real(DP), dimension(:), pointer, contiguous :: tstop ! particle stop time
+    real(DP), dimension(:), pointer, contiguous :: ttrack ! time to which particle has been tracked
 
   contains
+    procedure, public :: allocate_arrays
+    procedure, public :: deallocate_arrays
     procedure, public :: update_from_particle
   end type ParticleListType
 
@@ -108,6 +110,60 @@ contains
     deallocate (this%iTrackingDomainBoundary)
     return
   end subroutine destroy_particle
+
+  subroutine allocate_arrays(this, np, lMin, lMax, mempath)
+    ! -- modules
+    use MemoryManagerModule, only: mem_allocate
+    ! -- dummy
+    class(ParticleListType), intent(inout) :: this
+    integer(I4B), intent(in) :: np ! number of particles
+    integer(I4B), intent(in) :: lMin ! minimum level in the tracking domain hierarchy
+    integer(I4B), intent(in) :: lMax ! maximum level in the tracking domain hierarchy
+    character(*), intent(in) :: mempath ! path to memory
+    !
+    call mem_allocate(this%irpt, np, 'PLIRPT', mempath)
+    call mem_allocate(this%iprp, np, 'PLIPRP', mempath)
+    call mem_allocate(this%iTrackingDomain, np, lMax - lmin, 'PLITD', mempath) ! kluge note: ditch crazy dims
+    call mem_allocate(this%iTrackingDomainBoundary, np, &
+                      lMax - lmin, 'PLITDB', mempath) ! kluge note: ditch crazy dims
+    call mem_allocate(this%izone, np, 'PLIZONE', mempath)
+    call mem_allocate(this%istatus, np, 'PLISTATUS', mempath)
+    call mem_allocate(this%x, np, 'PLX', mempath)
+    call mem_allocate(this%y, np, 'PLY', mempath)
+    call mem_allocate(this%z, np, 'PLZ', mempath)
+    call mem_allocate(this%trelease, np, 'PLTRELEASE', mempath)
+    call mem_allocate(this%tstop, np, 'PLTSTOP', mempath)
+    call mem_allocate(this%ttrack, np, 'PLTTRACK', mempath)
+    call mem_allocate(this%istopweaksink, np, 'PLISTOPWEAKSINK', mempath)
+    call mem_allocate(this%istopzone, np, 'PLISTOPZONE', mempath)
+    !
+    return
+  end subroutine allocate_arrays
+
+  subroutine deallocate_arrays(this, mempath)
+    ! -- modules
+    use MemoryManagerModule, only: mem_deallocate
+    ! -- dummy
+    class(ParticleListType), intent(inout) :: this
+    character(*), intent(in) :: mempath ! path to memory
+    !
+    call mem_deallocate(this%irpt, 'PLIRPT', mempath)
+    call mem_deallocate(this%iprp, 'PLIPRP', mempath)
+    call mem_deallocate(this%iTrackingDomain, 'PLITD', mempath)
+    call mem_deallocate(this%iTrackingDomainBoundary, 'PLITDB', mempath)
+    call mem_deallocate(this%izone, 'PLIZONE', mempath)
+    call mem_deallocate(this%istatus, 'PLISTATUS', mempath)
+    call mem_deallocate(this%x, 'PLX', mempath)
+    call mem_deallocate(this%y, 'PLY', mempath)
+    call mem_deallocate(this%z, 'PLZ', mempath)
+    call mem_deallocate(this%trelease, 'PLTRELEASE', mempath)
+    call mem_deallocate(this%tstop, 'PLTSTOP', mempath)
+    call mem_deallocate(this%ttrack, 'PLTTRACK', mempath)
+    call mem_deallocate(this%istopweaksink, 'PLISTOPWEAKSINK', mempath)
+    call mem_deallocate(this%istopzone, 'PLISTOPZONE', mempath)
+    !
+    return
+  end subroutine deallocate_arrays
 
   subroutine update_from_list(this, partlist, im, iprp, irpt)
     ! -- dummy

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -111,21 +111,25 @@ contains
     return
   end subroutine destroy_particle
 
-  subroutine allocate_arrays(this, np, lMin, lMax, mempath)
+  subroutine allocate_arrays(this, np, lmin, lmax, mempath)
     ! -- modules
     use MemoryManagerModule, only: mem_allocate
     ! -- dummy
     class(ParticleListType), intent(inout) :: this
     integer(I4B), intent(in) :: np ! number of particles
-    integer(I4B), intent(in) :: lMin ! minimum level in the tracking domain hierarchy
-    integer(I4B), intent(in) :: lMax ! maximum level in the tracking domain hierarchy
+    integer(I4B), intent(in) :: lmin ! minimum level in the tracking domain hierarchy
+    integer(I4B), intent(in) :: lmax ! maximum level in the tracking domain hierarchy
     character(*), intent(in) :: mempath ! path to memory
     !
     call mem_allocate(this%irpt, np, 'PLIRPT', mempath)
     call mem_allocate(this%iprp, np, 'PLIPRP', mempath)
-    call mem_allocate(this%iTrackingDomain, np, lMax - lmin, 'PLITD', mempath) ! kluge note: ditch crazy dims
-    call mem_allocate(this%iTrackingDomainBoundary, np, &
-                      lMax - lmin, 'PLITDB', mempath) ! kluge note: ditch crazy dims
+    ! -- kluge todo: update mem_allocate to allow custom range of indices?
+    !    e.g. here we want to allocate 0-4 for trackdomain levels, not 1-5
+    ! call mem_allocate(this%iTrackingDomain, np, lmax - lmin + 1, 'PLITD', mempath) ! kluge note: ditch crazy dims
+    ! call mem_allocate(this%iTrackingDomainBoundary, np, &
+    !                   lmax - lmin + 1, 'PLITDB', mempath) ! kluge note: ditch crazy dims
+    allocate (this%iTrackingDomain(np, lmin:lmax))
+    allocate (this%iTrackingDomainBoundary(np, lmin:lmax))
     call mem_allocate(this%izone, np, 'PLIZONE', mempath)
     call mem_allocate(this%istatus, np, 'PLISTATUS', mempath)
     call mem_allocate(this%x, np, 'PLX', mempath)
@@ -149,8 +153,10 @@ contains
     !
     call mem_deallocate(this%irpt, 'PLIRPT', mempath)
     call mem_deallocate(this%iprp, 'PLIPRP', mempath)
-    call mem_deallocate(this%iTrackingDomain, 'PLITD', mempath)
-    call mem_deallocate(this%iTrackingDomainBoundary, 'PLITDB', mempath)
+    ! call mem_deallocate(this%iTrackingDomain, 'PLITD', mempath)
+    ! call mem_deallocate(this%iTrackingDomainBoundary, 'PLITDB', mempath)
+    deallocate (this%iTrackingDomain)
+    deallocate (this%iTrackingDomainBoundary)
     call mem_deallocate(this%izone, 'PLIZONE', mempath)
     call mem_deallocate(this%istatus, 'PLISTATUS', mempath)
     call mem_deallocate(this%x, 'PLX', mempath)

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -69,8 +69,8 @@ module ParticleModule
     integer(I4B), dimension(:), pointer, contiguous :: istopzone !< stop zone number
 
     ! tracking domain
-    integer(I4B), dimension(:, :), pointer, contiguous :: iTrackingDomain ! array of indices for domains in the tracking domain hierarchy
-    integer(I4B), dimension(:, :), pointer, contiguous :: iTrackingDomainBoundary ! array of indices for tracking domain boundaries
+    integer(I4B), dimension(:, :), allocatable :: iTrackingDomain ! array of indices for domains in the tracking domain hierarchy
+    integer(I4B), dimension(:, :), allocatable :: iTrackingDomainBoundary ! array of indices for tracking domain boundaries
 
     ! track data
     integer(I4B), dimension(:), pointer, contiguous :: izone !< current zone number
@@ -85,6 +85,7 @@ module ParticleModule
   contains
     procedure, public :: allocate_arrays
     procedure, public :: deallocate_arrays
+    procedure, public :: reallocate_arrays
     procedure, public :: update_from_particle
   end type ParticleListType
 
@@ -170,6 +171,42 @@ contains
     !
     return
   end subroutine deallocate_arrays
+
+  subroutine reallocate_arrays(this, np, mempath)
+    ! -- modules
+    use MemoryManagerModule, only: mem_reallocate
+    use ArrayHandlersModule, only: ExpandArray2D
+    ! -- dummy
+    class(ParticleListType), intent(inout) :: this
+    integer(I4B), intent(in) :: np ! number of particles
+    character(*), intent(in) :: mempath ! path to memory
+    !
+    ! resize 1D arrays
+    call mem_reallocate(this%irpt, np, 'PLIRPT', mempath)
+    call mem_reallocate(this%iprp, np, 'PLIPRP', mempath)
+    call mem_reallocate(this%izone, np, 'PLIZONE', mempath)
+    call mem_reallocate(this%istatus, np, 'PLISTATUS', mempath)
+    call mem_reallocate(this%x, np, 'PLX', mempath)
+    call mem_reallocate(this%y, np, 'PLY', mempath)
+    call mem_reallocate(this%z, np, 'PLZ', mempath)
+    call mem_reallocate(this%trelease, np, 'PLTRELEASE', mempath)
+    call mem_reallocate(this%tstop, np, 'PLTSTOP', mempath)
+    call mem_reallocate(this%ttrack, np, 'PLTTRACK', mempath)
+    call mem_reallocate(this%istopweaksink, np, 'PLISTOPWEAKSINK', mempath)
+    call mem_reallocate(this%istopzone, np, 'PLISTOPZONE', mempath)
+    !
+    ! resize first dimension of 2D arrays
+    call ExpandArray2D( &
+      this%iTrackingDomain, &
+      size(this%iTrackingDomain(:, 1) - np), &
+      0)
+    call ExpandArray2D( &
+      this%iTrackingDomainBoundary, &
+      size(this%iTrackingDomainBoundary(:, 1) - np), &
+      0)
+    !
+    return
+  end subroutine reallocate_arrays
 
   subroutine update_from_list(this, partlist, im, iprp, irpt)
     ! -- dummy

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -83,6 +83,7 @@ module ParticleModule
     real(DP), dimension(:), pointer, contiguous :: ttrack ! time to which particle has been tracked
 
   contains
+    procedure, public :: count
     procedure, public :: allocate_arrays
     procedure, public :: deallocate_arrays
     procedure, public :: reallocate_arrays
@@ -90,6 +91,11 @@ module ParticleModule
   end type ParticleListType
 
 contains
+
+  pure integer function count(this)
+    class(ParticleListType), intent(in) :: this
+    count = size(this%irpt)
+  end function
 
   !> @brief Create a new particle
   subroutine create_particle(particle)


### PR DESCRIPTION
- add `init_from_list` routine to `ParticleType`
- add `update_from_particle` routine to `ParticleListType`
- add `[de/re]allocate_arrays` routines to `ParticleListType` and `TrackDataType`
  - dynamic reallocation of PRP-package-owned arrays identifying particles
    - expand by number of release points if needed at release time
    - necessary to accommodate repeated releases
  - dynamic reallocation of PRT-model-owned arrays storing particle tracks
    - expand 10x if at capacity
    - shrink 10x if using <1% capacity