### PR TITLE
test(PRT): unit test Particle and TrackData dynamic reallocation

### DIFF
--- a/autotest/driver.f90
+++ b/autotest/driver.f90
@@ -7,6 +7,7 @@ program tester
   use test_Sim, only : collect_Sim
   use test_InputOutput, only : collect_InputOutput
   use test_GenericUtils, only : collect_GenericUtils
+  use test_ArrayHandlers, only : collect_ArrayHandlers
   use test_prt_CellUtil, only: collect_prt_CellUtil
   use test_prt_MethodSubcellPollock, only : collect_prt_MethodSubcellPollock
   use test_prt_particle, only : collect_prt_Particle
@@ -26,6 +27,7 @@ program tester
     new_testsuite("Sim", collect_Sim), &
     new_testsuite("GenericUtils", collect_GenericUtils), &
     new_testsuite("InputOutput", collect_InputOutput), &
+    new_testsuite("ArrayHandlers", collect_ArrayHandlers), &
     new_testsuite("prt_CellUtil", collect_prt_CellUtil), &
     new_testsuite("prt_MethodSubcellPollock", collect_prt_MethodSubcellPollock), &
     new_testsuite("prt_Particle", collect_prt_Particle), &

--- a/autotest/driver.f90
+++ b/autotest/driver.f90
@@ -1,19 +1,20 @@
 program tester
-  use, intrinsic :: iso_fortran_env, only : error_unit
-  use testdrive, only : run_testsuite, new_testsuite, testsuite_type, &
+  use, intrinsic :: iso_fortran_env, only: error_unit
+  use testdrive, only: run_testsuite, new_testsuite, testsuite_type, &
     & select_suite, run_selected, get_argument
-  use test_Demo, only : collect_Demo
-  use test_List, only : collect_List
-  use test_Sim, only : collect_Sim
-  use test_InputOutput, only : collect_InputOutput
-  use test_GenericUtils, only : collect_GenericUtils
-  use test_ArrayHandlers, only : collect_ArrayHandlers
+  use test_Demo, only: collect_Demo
+  use test_List, only: collect_List
+  use test_Sim, only: collect_Sim
+  use test_InputOutput, only: collect_InputOutput
+  use test_GenericUtils, only: collect_GenericUtils
+  use test_ArrayHandlers, only: collect_ArrayHandlers
   use test_prt_CellUtil, only: collect_prt_CellUtil
-  use test_prt_MethodSubcellPollock, only : collect_prt_MethodSubcellPollock
-  use test_prt_particle, only : collect_prt_Particle
-  use test_prt_TernaryUtil, only : collect_prt_TernaryUtil
-  use test_prt_TernarySolveTrack, only : collect_prt_TernarySolveTrack
-  use test_prt_UtilMisc, only : collect_prt_UtilMisc
+  use test_prt_MethodSubcellPollock, only: collect_prt_MethodSubcellPollock
+  use test_prt_particle, only: collect_prt_Particle
+  use test_prt_TernaryUtil, only: collect_prt_TernaryUtil
+  use test_prt_TernarySolveTrack, only: collect_prt_TernarySolveTrack
+  use test_prt_UtilMisc, only: collect_prt_UtilMisc
+  use test_prt_TrackData, only: collect_prt_TrackData
   implicit none
   integer :: stat, is
   character(len=:), allocatable :: suite_name, test_name
@@ -22,19 +23,22 @@ program tester
 
   stat = 0
   testsuites = [ &
-    new_testsuite("Demo", collect_Demo), &
-    new_testsuite("List", collect_List), &
-    new_testsuite("Sim", collect_Sim), &
-    new_testsuite("GenericUtils", collect_GenericUtils), &
-    new_testsuite("InputOutput", collect_InputOutput), &
-    new_testsuite("ArrayHandlers", collect_ArrayHandlers), &
-    new_testsuite("prt_CellUtil", collect_prt_CellUtil), &
-    new_testsuite("prt_MethodSubcellPollock", collect_prt_MethodSubcellPollock), &
-    new_testsuite("prt_Particle", collect_prt_Particle), &
-    new_testsuite("prt_TernaryUtil", collect_prt_TernaryUtil), &
-    new_testsuite("prt_TernarySolveTrack", collect_prt_TernarySolveTrack), &
-    new_testsuite("prt_UtilMisc", collect_prt_UtilMisc) &
-  ]
+               new_testsuite("Demo", collect_Demo), &
+               new_testsuite("List", collect_List), &
+               new_testsuite("Sim", collect_Sim), &
+               new_testsuite("GenericUtils", collect_GenericUtils), &
+               new_testsuite("InputOutput", collect_InputOutput), &
+               new_testsuite("ArrayHandlers", collect_ArrayHandlers), &
+               new_testsuite("prt_CellUtil", collect_prt_CellUtil), &
+               new_testsuite("prt_MethodSubcellPollock", &
+                             collect_prt_MethodSubcellPollock), &
+               new_testsuite("prt_Particle", collect_prt_Particle), &
+               new_testsuite("prt_TernaryUtil", collect_prt_TernaryUtil), &
+               new_testsuite("prt_TernarySolveTrack", &
+                             collect_prt_TernarySolveTrack), &
+               new_testsuite("prt_UtilMisc", collect_prt_UtilMisc), &
+               new_testsuite("prt_TrackData", collect_prt_TrackData) &
+               ]
 
   call get_argument(1, suite_name)
   call get_argument(2, test_name)
@@ -43,31 +47,31 @@ program tester
     is = select_suite(testsuites, suite_name)
     if (is > 0 .and. is <= size(testsuites)) then
       if (allocated(test_name)) then
-        write(error_unit, fmt) "Suite:", testsuites(is)%name
+        write (error_unit, fmt) "Suite:", testsuites(is)%name
         call run_selected(testsuites(is)%collect, test_name, error_unit, stat)
         if (stat < 0) then
           error stop 1
         end if
       else
-        write(error_unit, fmt) "Testing:", testsuites(is)%name
+        write (error_unit, fmt) "Testing:", testsuites(is)%name
         call run_testsuite(testsuites(is)%collect, error_unit, stat)
       end if
     else
-      write(error_unit, fmt) "Available testsuites"
+      write (error_unit, fmt) "Available testsuites"
       do is = 1, size(testsuites)
-        write(error_unit, fmt) "-", testsuites(is)%name
+        write (error_unit, fmt) "-", testsuites(is)%name
       end do
       error stop 1
     end if
   else
     do is = 1, size(testsuites)
-      write(error_unit, fmt) "Testing:", testsuites(is)%name
+      write (error_unit, fmt) "Testing:", testsuites(is)%name
       call run_testsuite(testsuites(is)%collect, error_unit, stat)
     end do
   end if
 
   if (stat > 0) then
-    write(error_unit, '(i0, 1x, a)') stat, "test(s) failed!"
+    write (error_unit, '(i0, 1x, a)') stat, "test(s) failed!"
     error stop 1
   end if
 

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -4,6 +4,7 @@ tests = [
   'Sim',
   'InputOutput',
   'GenericUtils',
+  'ArrayHandlers',
   'prt_UtilMisc',
   'prt_CellUtil',
   'prt_MethodSubcellPollock',

--- a/autotest/meson.build
+++ b/autotest/meson.build
@@ -10,7 +10,8 @@ tests = [
   'prt_MethodSubcellPollock',
   'prt_Particle',
   'prt_TernaryUtil',
-  'prt_TernarySolveTrack'
+  'prt_TernarySolveTrack',
+  'prt_TrackData'
 ]
 
 test_srcs = files(

--- a/autotest/test_ArrayHandlers.F90
+++ b/autotest/test_ArrayHandlers.F90
@@ -1,0 +1,41 @@
+module test_arrayhandlers
+  use KindModule, only: I4B
+  use testdrive, only: error_type, unittest_type, new_unittest, check
+  use UtilMiscModule, only: FirstNonBlank, GetLayerRowColumn
+  use ArrayHandlersModule, only: ExpandArray2D
+  use ConstantsModule, only: LINELENGTH
+  implicit none
+  private
+  public :: collect_arrayhandlers
+
+contains
+
+  subroutine collect_arrayhandlers(testsuite)
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    testsuite = [ &
+                new_unittest("ExpandArray2D_int", test_ExpandArray2D_int) &
+                ]
+  end subroutine collect_arrayhandlers
+
+  subroutine test_ExpandArray2D_int(error)
+    type(error_type), allocatable, intent(out) :: error
+    integer, allocatable :: array(:, :)
+
+    ! allocate array
+    allocate (array(2, 2))
+
+    ! check initial array size
+    call check(error, size(array, 1) == 2)
+    call check(error, size(array, 2) == 2)
+    if (allocated(error)) return
+
+    ! resize array
+    call ExpandArray2D(array, 2, 2)
+
+    ! check that arrays have been resized
+    call check(error, size(array, 1) == 4)
+    call check(error, size(array, 2) == 4)
+    if (allocated(error)) return
+
+  end subroutine test_ExpandArray2D_int
+end module test_arrayhandlers

--- a/autotest/test_prt_Particle.F90
+++ b/autotest/test_prt_Particle.F90
@@ -1,25 +1,91 @@
 module test_prt_particle
-    use testdrive, only: error_type, unittest_type, new_unittest, check
-    use ParticleModule, only: ParticleType, create_particle, get_particle_id
-    implicit none
-    private
-    public :: collect_prt_Particle
-    contains
+  use testdrive, only: error_type, unittest_type, new_unittest, check
+  use ParticleModule, only: ParticleType, ParticleListType, &
+                            create_particle, get_particle_id
+  implicit none
+  private
+  public :: collect_prt_Particle
+contains
 
-    subroutine collect_prt_Particle(testsuite)
-        type(unittest_type), allocatable, intent(out) :: testsuite(:)
-        testsuite = [new_unittest("get_particle_id", test_get_particle_id)]
-    end subroutine collect_prt_Particle
+  subroutine collect_prt_Particle(testsuite)
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    testsuite = [ &
+                new_unittest("dynamic_allocation", test_dynamic_allocation), &
+                new_unittest("get_particle_id", test_get_particle_id) &
+                ]
+  end subroutine collect_prt_Particle
 
-    subroutine test_get_particle_id(error)
-        type(error_type), allocatable, intent(out) :: error
-        type(ParticleType), pointer :: p
+  subroutine test_get_particle_id(error)
+    type(error_type), allocatable, intent(out) :: error
+    type(ParticleType), pointer :: p
 
-        call create_particle(p)
-        p%iprp = 0
-        p%irpt = 0
-        p%trelease = 0.0
-        print *, "Particle ID: ", get_particle_id(p)
-        call check(error, get_particle_id(p) == "0-0-0.")
-    end subroutine test_get_particle_id
+    call create_particle(p)
+    p%iprp = 0
+    p%irpt = 0
+    p%trelease = 0.0
+    print *, "Particle ID: ", get_particle_id(p)
+    call check(error, get_particle_id(p) == "0-0-0.")
+
+  end subroutine test_get_particle_id
+
+  subroutine test_dynamic_allocation(error)
+    ! -- modules
+    use GlobalDataModule, only: levelMin, levelMax
+    use ConstantsModule, only: LENMEMPATH, I4B
+
+    ! -- dummy
+    type(error_type), allocatable, intent(out) :: error
+
+    ! -- locals
+    type(ParticleListType), pointer :: partlist => null()
+    integer(I4B) :: npartmax1 = 10
+    integer(I4B) :: npartmax2 = 20
+    integer(I4B) :: nlevels = levelMax - levelMin + 1
+    character(len=LENMEMPATH) :: mempath = "test_dynamic_allocation"
+
+    ! allocate particle arrays
+    allocate (partlist)
+    call partlist%allocate_arrays(npartmax1, levelMin, levelMax, mempath)
+
+    ! check initial array sizes
+    call check(error, size(partlist%x) == npartmax1)
+    call check(error, size(partlist%y) == npartmax1)
+    call check(error, size(partlist%z) == npartmax1)
+    call check(error, size(partlist%trelease) == npartmax1)
+    call check(error, size(partlist%tstop) == npartmax1)
+    call check(error, size(partlist%ttrack) == npartmax1)
+    call check(error, size(partlist%istopweaksink) == npartmax1)
+    call check(error, size(partlist%istopzone) == npartmax1)
+    call check(error, size(partlist%istatus) == npartmax1)
+    call check(error, size(partlist%irpt) == npartmax1)
+    call check(error, size(partlist%iprp) == npartmax1)
+    call check(error, size(partlist%iTrackingDomain, 1) == npartmax1)
+    call check(error, size(partlist%iTrackingDomain, 2) == nlevels)
+    call check(error, size(partlist%iTrackingDomainBoundary, 1) == npartmax1)
+    call check(error, size(partlist%iTrackingDomainBoundary, 2) == nlevels)
+    if (allocated(error)) return
+
+    ! resize particle arrays
+    call partlist%reallocate_arrays(npartmax2, mempath)
+
+    ! check that arrays have been resized
+    call check(error, size(partlist%x) == npartmax2)
+    call check(error, size(partlist%y) == npartmax2)
+    call check(error, size(partlist%z) == npartmax2)
+    call check(error, size(partlist%trelease) == npartmax2)
+    call check(error, size(partlist%tstop) == npartmax2)
+    call check(error, size(partlist%ttrack) == npartmax2)
+    call check(error, size(partlist%istopweaksink) == npartmax2)
+    call check(error, size(partlist%istopzone) == npartmax2)
+    call check(error, size(partlist%istatus) == npartmax2)
+    call check(error, size(partlist%irpt) == npartmax2)
+    call check(error, size(partlist%iprp) == npartmax2)
+    call check(error, size(partlist%iTrackingDomain, 1) == npartmax2)
+    call check(error, size(partlist%iTrackingDomain, 2) == nlevels)
+    call check(error, size(partlist%iTrackingDomainBoundary, 1) == npartmax2)
+    call check(error, size(partlist%iTrackingDomainBoundary, 2) == nlevels)
+    if (allocated(error)) return
+
+  end subroutine test_dynamic_allocation
+
 end module test_prt_particle

--- a/autotest/test_prt_TrackData.F90
+++ b/autotest/test_prt_TrackData.F90
@@ -1,0 +1,209 @@
+module test_prt_trackdata
+  use testdrive, only: error_type, unittest_type, new_unittest, check
+  use ParticleModule, only: ParticleType, ParticleListType, &
+                            create_particle, get_particle_id
+  use TrackDataModule, only: TrackDataType
+  implicit none
+  private
+  public :: collect_prt_TrackData
+contains
+
+  subroutine collect_prt_TrackData(testsuite)
+    type(unittest_type), allocatable, intent(out) :: testsuite(:)
+    testsuite = [ &
+                new_unittest("reallocate", test_reallocate), &
+                new_unittest("add_track_data", test_add_track_data) &
+                ]
+  end subroutine collect_prt_TrackData
+
+  subroutine test_reallocate(error)
+    ! -- modules
+    use GlobalDataModule, only: levelMin, levelMax
+    use ConstantsModule, only: LENMEMPATH, I4B
+
+    ! -- dummy
+    type(error_type), allocatable, intent(out) :: error
+
+    ! -- locals
+    type(ParticleType), pointer :: particle => null()
+    type(TrackDataType), pointer :: trackdata => null()
+    integer(I4B) :: nt1 = 10
+    integer(I4B) :: nt2 = 20
+    character(len=LENMEMPATH) :: mempath = "test_reallocate"
+
+    ! allocate and initialize particle
+    call create_particle(particle)
+    particle%irpt = 0
+    particle%iprp = 0
+    particle%istopzone = 0
+    particle%istopweaksink = 0
+    particle%iTrackingDomain(levelMin:levelMax) = 0
+    particle%iTrackingDomainBoundary(levelMin:levelMax) = 0
+    particle%izone = 0
+    particle%istatus = 0
+    particle%x = 0
+    particle%y = 0
+    particle%z = 0
+    particle%trelease = 0
+    particle%tstop = 0
+    particle%ttrack = 0
+    particle%isTransformed = .false.
+    particle%xOrigin = 0.0
+    particle%yOrigin = 0.0
+    particle%zOrigin = 0.0
+    particle%sinrot = 0.0
+    particle%cosrot = 0.0
+
+    ! allocate track data
+    allocate (trackdata)
+    call trackdata%allocate_arrays(nt1, mempath)
+
+    ! check initial array sizes
+    call check(error, size(trackdata%kper) == nt1)
+    call check(error, size(trackdata%kstp) == nt1)
+    call check(error, size(trackdata%irpt) == nt1)
+    call check(error, size(trackdata%iprp) == nt1)
+    call check(error, size(trackdata%icell) == nt1)
+    call check(error, size(trackdata%izone) == nt1)
+    call check(error, size(trackdata%istatus) == nt1)
+    call check(error, size(trackdata%ireason) == nt1)
+    call check(error, size(trackdata%trelease) == nt1)
+    call check(error, size(trackdata%t) == nt1)
+    call check(error, size(trackdata%x) == nt1)
+    call check(error, size(trackdata%y) == nt1)
+    call check(error, size(trackdata%z) == nt1)
+    if (allocated(error)) return
+
+    ! resize particle arrays
+    call trackdata%reallocate_arrays(nt2, mempath)
+
+    ! check that arrays have been resized
+    call check(error, size(trackdata%kper) == nt2)
+    call check(error, size(trackdata%kstp) == nt2)
+    call check(error, size(trackdata%irpt) == nt2)
+    call check(error, size(trackdata%iprp) == nt2)
+    call check(error, size(trackdata%icell) == nt2)
+    call check(error, size(trackdata%izone) == nt2)
+    call check(error, size(trackdata%istatus) == nt2)
+    call check(error, size(trackdata%ireason) == nt2)
+    call check(error, size(trackdata%trelease) == nt2)
+    call check(error, size(trackdata%t) == nt2)
+    call check(error, size(trackdata%x) == nt2)
+    call check(error, size(trackdata%y) == nt2)
+    call check(error, size(trackdata%z) == nt2)
+    if (allocated(error)) return
+
+  end subroutine test_reallocate
+
+  subroutine test_add_track_data(error)
+    ! -- modules
+    use GlobalDataModule, only: levelMin, levelMax
+    use ConstantsModule, only: LENMEMPATH, I4B
+
+    ! -- dummy
+    type(error_type), allocatable, intent(out) :: error
+
+    ! -- locals
+    type(ParticleType), pointer :: particle
+    type(TrackDataType), pointer :: trackdata => null()
+    integer(I4B) :: nt1 = 1
+    integer(I4B) :: nt2
+    integer(I4B) :: kper = 1, kstp = 1
+    character(len=LENMEMPATH) :: mempath = "test_add_track_data"
+
+    ! allocate and initialize particle
+    print *, "allocating particle"
+    call create_particle(particle)
+    particle%irpt = 0
+    particle%iprp = 0
+    particle%istopzone = 0
+    particle%istopweaksink = 0
+    particle%iTrackingDomain(levelMin:levelMax) = 0
+    particle%iTrackingDomainBoundary(levelMin:levelMax) = 0
+    particle%izone = 0
+    particle%istatus = 0
+    particle%x = 0
+    particle%y = 0
+    particle%z = 0
+    particle%trelease = 0
+    particle%tstop = 0
+    particle%ttrack = 0
+    particle%isTransformed = .false.
+    particle%xOrigin = 0.0
+    particle%yOrigin = 0.0
+    particle%zOrigin = 0.0
+    particle%sinrot = 0.0
+    particle%cosrot = 0.0
+
+    ! allocate track data to initial size of 1
+    print *, "allocating trackdata"
+    allocate (trackdata)
+    allocate (trackdata%ntrack)
+    trackdata%ntrack = 0
+    call trackdata%allocate_arrays(nt1, mempath)
+
+    ! check initial array sizes
+    print *, "checking initial trackdata size"
+    call check(error, size(trackdata%kper) == nt1)
+    call check(error, size(trackdata%kstp) == nt1)
+    call check(error, size(trackdata%irpt) == nt1)
+    call check(error, size(trackdata%iprp) == nt1)
+    call check(error, size(trackdata%icell) == nt1)
+    call check(error, size(trackdata%izone) == nt1)
+    call check(error, size(trackdata%istatus) == nt1)
+    call check(error, size(trackdata%ireason) == nt1)
+    call check(error, size(trackdata%trelease) == nt1)
+    call check(error, size(trackdata%t) == nt1)
+    call check(error, size(trackdata%x) == nt1)
+    call check(error, size(trackdata%y) == nt1)
+    call check(error, size(trackdata%z) == nt1)
+    if (allocated(error)) return
+
+    ! add particle to track data
+    print *, "adding first particle to track data"
+    call trackdata%add_track_data(particle, kper=kper, &
+                                  kstp=kstp, reason=0)
+
+    ! check track data values
+    print *, "checking initial track data values"
+    call check(error, trackdata%kper(1) == 1)
+    call check(error, trackdata%kstp(1) == 1)
+    call check(error, trackdata%irpt(1) == 0)
+    call check(error, trackdata%iprp(1) == 0)
+    call check(error, trackdata%icell(1) == 0)
+    call check(error, trackdata%izone(1) == 0)
+    call check(error, trackdata%istatus(1) == 0)
+    call check(error, trackdata%ireason(1) == 0)
+    call check(error, trackdata%trelease(1) == 0)
+    call check(error, trackdata%t(1) == 0)
+    call check(error, trackdata%x(1) == 0)
+    call check(error, trackdata%y(1) == 0)
+    call check(error, trackdata%z(1) == 0)
+    if (allocated(error)) return
+
+    ! add another particle to track data
+    print *, "adding another particle to track data"
+    call trackdata%add_track_data(particle, kper=kper, &
+                                  kstp=kstp, reason=0)
+
+    ! check that arrays were automatically expanded by factor of 10
+    print *, "checking arrays were expanded by factor of 10"
+    nt2 = nt1 * 10
+    call check(error, size(trackdata%kper) == nt2)
+    call check(error, size(trackdata%kstp) == nt2)
+    call check(error, size(trackdata%irpt) == nt2)
+    call check(error, size(trackdata%iprp) == nt2)
+    call check(error, size(trackdata%icell) == nt2)
+    call check(error, size(trackdata%izone) == nt2)
+    call check(error, size(trackdata%istatus) == nt2)
+    call check(error, size(trackdata%ireason) == nt2)
+    call check(error, size(trackdata%trelease) == nt2)
+    call check(error, size(trackdata%t) == nt2)
+    call check(error, size(trackdata%x) == nt2)
+    call check(error, size(trackdata%y) == nt2)
+    call check(error, size(trackdata%z) == nt2)
+    if (allocated(error)) return
+
+  end subroutine test_add_track_data
+
+end module test_prt_trackdata

--- a/src/Model/ModelUtilities/TrackData.f90
+++ b/src/Model/ModelUtilities/TrackData.f90
@@ -28,8 +28,12 @@ module TrackDataModule
   !   - irpt: particle release location ID
   !   - trelease: particle release time (retrieved from partlist)
   type :: TrackDataType
-    ! integer arrays
+
+    ! kluge??? if mem_reallocate was called from the PRT module
+    ! instead of within this module, this wouldn't be necessary
     character(len=:), pointer :: mempath => null() ! memory path of track data
+
+    ! integer arrays
     integer(I4B), pointer :: ntrack => null() ! total count of track data
     integer(I4B), dimension(:), pointer, contiguous :: kper ! stress period
     integer(I4B), dimension(:), pointer, contiguous :: kstp ! time step
@@ -71,7 +75,10 @@ contains
     class(TrackDataType), intent(inout) :: this
     integer(I4B), intent(in) :: nt
     character(len=*), intent(in) :: mempath
-    !
+
+    ! -- this routine only accepts a mempath parameter because
+    ! -- the memory manager mem_reallocate routine requires it
+
     ! print *, 'allocating ', nt, ' slots for track data arrays'
     allocate (character(len=len(mempath)) :: this%mempath)
     ! call mem_allocate(this%mempath, size(mempath), 'TRACKMEMPATH', mempath)
@@ -145,12 +152,11 @@ contains
   end subroutine reallocate_arrays
 
   !> @brief Add track data from a particle
-  subroutine add_track_data(this, particle, reason, level)
-    ! -- modules
-    use TdisModule, only: kper, kstp
+  subroutine add_track_data(this, particle, kper, kstp, reason, level)
     ! -- dummy
     class(TrackDataType), intent(inout) :: this
     type(ParticleType), pointer, intent(in) :: particle
+    integer(I4B), intent(in) :: kper, kstp
     integer(I4B), intent(in) :: reason
     integer(I4B), intent(in), optional :: level
     ! -- local
@@ -227,8 +233,6 @@ contains
   !!
   !<
   subroutine save_track_data(this, itrkun, csv, itrack1, itrack2)
-    ! -- modules
-    use ParticleModule, only: ParticleListType
     ! -- dummy
     class(TrackDataType), intent(inout) :: this
     integer(I4B), intent(in) :: itrkun

--- a/src/Model/ParticleTracking/prt1.f90
+++ b/src/Model/ParticleTracking/prt1.f90
@@ -1379,9 +1379,7 @@ contains
   subroutine prt_solve(this)
     ! -- modules
     ! kluge note: kper for plotting only; is delt needed?
-    use TdisModule, only: kper, totimc, totim
-    ! -- modules
-    use TdisModule, only: nper, nstp
+    use TdisModule, only: kper, kstp, totimc, totim, nper, nstp
     use PrtPrpModule, only: PrtPrpType
     ! -- dummy variables
     class(PrtModelType) :: this
@@ -1403,10 +1401,7 @@ contains
     !
     ! -- Shrink track arrays by a factor of resizefactor
     ! -- if less than (resizefraction * 100)% is in use.
-    ! -- Never shrink below the intial trackdata size
-    ! -- purpose of resizethresh is to prevent shrinking
-    ! -- when the track array size is small. Also, never
-    ! -- shrink below minimum size (particle count) * 2.
+    ! -- Never shrink below the initial trackdata size.
     resizefactor = 10
     resizethresh = INITIAL_TRACK_SIZE
     resizefraction = 0.01
@@ -1436,7 +1431,8 @@ contains
           ! -- If particle inactive, record (unchanged) location in track data and skip tracking
           ! kluge note: temporarily commented out recording of inactive particle data; want it, maybe as an option???
           if (packobj%partlist%istatus(np) .ne. 1 .and. save_inactive) then
-            call this%trackdata%add_track_data(particle, reason=4) ! reason=4 is inactive
+            call this%trackdata%add_track_data(particle, kper=kper, &
+                                               kstp=kstp, reason=4)
             cycle
           end if
           !
@@ -1444,7 +1440,7 @@ contains
           call particle%reset_transf()
 
           ! -- Update particle properties from particle list
-          call particle%update_from_list(packobj%partlist, this%id, iprp, np)
+          call particle%init_from_list(packobj%partlist, this%id, iprp, np)
 
           ! if (particle%iTrackingDomain(2).eq.0) then
           ! if (particle%iTrackingDomain(2).lt.0) then
@@ -1476,7 +1472,8 @@ contains
           ! -- If particle released during this time step, record its
           ! -- initial location in track data
           if (particle%trelease .ge. totimc) then
-            call this%trackdata%add_track_data(particle, reason=0) ! reason=0 is release
+            call this%trackdata%add_track_data(particle, kper=kper, &
+                                               kstp=kstp, reason=0)
           end if
           !
           ! -- Apply the tracking method

--- a/src/Solution/ParticleTracker/Method.f90
+++ b/src/Solution/ParticleTracker/Method.f90
@@ -44,6 +44,8 @@ contains
 
   !> @brief Track particle across subdomains
   recursive subroutine subtrack(this, particle, level, tmax)
+    ! modules
+    use TdisModule, only: kper, kstp
     ! dummy
     class(MethodType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -72,7 +74,9 @@ contains
       call submethod%apply(particle, tmax)
       !
       ! -- Store particle trackdata as appropriate
-      call submethod%trackdata%add_track_data(particle, reason=1, level=levelNext)
+      call submethod%trackdata%add_track_data(particle, &
+                                              kper=kper, kstp=kstp, &
+                                              reason=1, level=levelNext)
       !
       ! -- Advance particle
       call advance(this, particle, levelNext, submethod, isStillAdvancing)

--- a/src/Solution/ParticleTracker/MethodCellPassToBot.f90
+++ b/src/Solution/ParticleTracker/MethodCellPassToBot.f90
@@ -100,6 +100,7 @@ contains
   subroutine apply_mCVP(this, particle, tmax)
     ! -- modules
     use UtilMiscModule
+    use TdisModule, only: kper, kstp
     ! -- dummy
     class(MethodCellPassToBotType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -133,7 +134,8 @@ contains
     end if
     !
     ! -- Store track data
-    call this%trackdata%add_track_data(particle, reason=1)
+    call this%trackdata%add_track_data(particle, kper=kper, &
+                                       kstp=kstp, reason=1)
     !
     return
     !

--- a/src/Solution/ParticleTracker/MethodCellPollock.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollock.f90
@@ -162,6 +162,7 @@ contains
   !> @brief Apply Pollock's method to a rectangular cell
   subroutine apply_mCP(this, particle, tmax)
     use UtilMiscModule
+    use TdisModule, only: kper, kstp
     ! -- dummy
     class(MethodCellPollockType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -196,7 +197,8 @@ contains
       if (particle%z > this%cellRect%cellDefn%top) then
         particle%z = this%cellRect%cellDefn%top
         ! -- Store track data
-        call this%trackdata%add_track_data(particle, reason=1)
+        call this%trackdata%add_track_data(particle, kper=kper, &
+                                           kstp=kstp, reason=1)
       end if
       !
       ! -- Transform particle location into local cell coordinates.

--- a/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
+++ b/src/Solution/ParticleTracker/MethodCellPollockQuad.f90
@@ -246,6 +246,7 @@ contains
   !> @brief Apply Pollock's quad method to a rectangular-quad cell
   subroutine apply_mCPQ(this, particle, tmax)
     use UtilMiscModule
+    use TdisModule, only: kper, kstp
     ! -- dummy
     class(MethodCellPollockQuadType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -280,7 +281,8 @@ contains
       if (particle%z > this%cellRectQuad%cellDefn%top) then
         particle%z = this%cellRectQuad%cellDefn%top
         ! -- Store track data
-        call this%trackdata%add_track_data(particle, 1)
+        call this%trackdata%add_track_data(particle, kper=kper, &
+                                           kstp=kstp, reason=1)
       end if
       !
       ! -- Transform particle location into local cell coordinates.

--- a/src/Solution/ParticleTracker/MethodCellTernary.f90
+++ b/src/Solution/ParticleTracker/MethodCellTernary.f90
@@ -177,6 +177,7 @@ contains
   !> @brief Apply the ternary method to a polygonal cell
   subroutine apply_mCT(this, particle, tmax)
     use ConstantsModule, only: DZERO, DONE, DHALF ! kluge???
+    use TdisModule, only: kper, kstp
     ! dummy
     class(MethodCellTernaryType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
@@ -216,7 +217,8 @@ contains
       if (particle%z > this%cellPoly%cellDefn%top) then
         particle%z = this%cellPoly%cellDefn%top
         ! -- Store track data
-        call this%trackdata%add_track_data(particle, reason=1)
+        call this%trackdata%add_track_data(particle, kper=kper, &
+                                           kstp=kstp, reason=1)
       end if
       !
       npolyverts = this%cellPoly%cellDefn%npolyverts

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -53,7 +53,7 @@ module ParticleModule
     procedure, public :: reset_transf
     procedure, public :: set_transf
     procedure, public :: transf_coords
-    procedure, public :: update_from_list
+    procedure, public :: init_from_list
   end type ParticleType
 
   ! -- Define the particle list type (ParticleListType)  ! kluge note: use separate module???
@@ -83,7 +83,6 @@ module ParticleModule
     real(DP), dimension(:), pointer, contiguous :: ttrack ! time to which particle has been tracked
 
   contains
-    procedure, public :: Count
     procedure, public :: allocate_arrays
     procedure, public :: deallocate_arrays
     procedure, public :: reallocate_arrays
@@ -91,11 +90,6 @@ module ParticleModule
   end type ParticleListType
 
 contains
-
-  pure integer(I4B) function Count(this) result(c)
-    class(ParticleListType), intent(in) :: this
-    c = size(this%irpt)
-  end function
 
   !> @brief Create a new particle
   subroutine create_particle(particle)
@@ -118,6 +112,7 @@ contains
     return
   end subroutine destroy_particle
 
+  !> @brief Allocate particle arrays
   subroutine allocate_arrays(this, np, lmin, lmax, mempath)
     ! -- modules
     use MemoryManagerModule, only: mem_allocate
@@ -151,6 +146,7 @@ contains
     return
   end subroutine allocate_arrays
 
+  !> @brief Deallocate particle arrays
   subroutine deallocate_arrays(this, mempath)
     ! -- modules
     use MemoryManagerModule, only: mem_deallocate
@@ -178,6 +174,7 @@ contains
     return
   end subroutine deallocate_arrays
 
+  !> @brief Reallocate particle arrays
   subroutine reallocate_arrays(this, np, mempath)
     ! -- modules
     use MemoryManagerModule, only: mem_reallocate
@@ -214,7 +211,8 @@ contains
     return
   end subroutine reallocate_arrays
 
-  subroutine update_from_list(this, partlist, im, iprp, irpt)
+  !> @brief Initialize particle from particle list
+  subroutine init_from_list(this, partlist, im, iprp, irpt)
     ! -- dummy
     class(ParticleType), intent(inout) :: this
     type(ParticleListType), intent(in) :: partlist
@@ -240,7 +238,7 @@ contains
     this%ttrack = partlist%ttrack(irpt)
     !
     return
-  end subroutine update_from_list
+  end subroutine init_from_list
 
   !> @brief Update particle list from particle
   subroutine update_from_particle(this, particle, np)


### PR DESCRIPTION
* Add minimal unit tests for dynamic reallocation of particle and pathline arrays
*  `TrackDataType`'s `add_track_data()` routine previously imported `TdisModule` for kper & kstp. Remove the import since `TdisModule` needs initialization and allocation. Inject kper & kstp from the calling context instead. Dependency injection makes testing easier