### PR TITLE
Integrate MIP with IDM

### DIFF
--- a/make/makedefaults
+++ b/make/makedefaults
@@ -57,14 +57,14 @@ OPTLEVEL ?= -O2
 # set the fortran flags
 ifeq ($(detected_OS), Windows)
 	ifeq ($(FC), gfortran)
-		FFLAGS ?= -static -fbacktrace -ffpe-summary=overflow -ffpe-trap=overflow,zero,invalid $(OS_macro) -fall-intrinsics -Wtabs -Wline-truncation -Wunused-label -Wunused-variable -pedantic -std=f2008 -Wcharacter-truncation -cpp
+		FFLAGS ?= -static -fbacktrace -ffpe-summary=overflow -ffpe-trap=overflow,zero,invalid -fall-intrinsics -pedantic -Wcharacter-truncation $(OS_macro) -Wtabs -Wline-truncation -Wunused-label -Wunused-variable -std=f2008 -cpp
 	endif
 else
 	ifeq ($(FC), gfortran)
-		FFLAGS ?= -fbacktrace -ffpe-summary=overflow -ffpe-trap=overflow,zero,invalid $(OS_macro) -fall-intrinsics -Wtabs -Wline-truncation -Wunused-label -Wunused-variable -pedantic -std=f2008 -Wcharacter-truncation -cpp
+		FFLAGS ?= -fbacktrace -ffpe-summary=overflow -ffpe-trap=overflow,zero,invalid -fall-intrinsics -pedantic -Wcharacter-truncation $(OS_macro) -Wtabs -Wline-truncation -Wunused-label -Wunused-variable -std=f2008 -cpp
 	endif
 	ifeq ($(FC), $(filter $(FC), ifort mpiifort))
-		FFLAGS ?= -no-heap-arrays -fpe0 -traceback -fpp
+		FFLAGS ?= -no-heap-arrays -fpe0 -traceback -Qdiag-disable:7416 -Qdiag-disable:7025 -Qdiag-disable:5268 -fpp
 		MODSWITCH = -module $(MODDIR)
 	endif
 	ifeq ($(FC), $(filter $(FC), ftn))

--- a/make/makefile
+++ b/make/makefile
@@ -6,36 +6,36 @@ include ./makedefaults
 # Define the source file directories
 SOURCEDIR1=../src
 SOURCEDIR2=../src/Exchange
-SOURCEDIR3=../src/Model
-SOURCEDIR4=../src/Model/Geometry
-SOURCEDIR5=../src/Model/ParticleTracking
-SOURCEDIR6=../src/Model/ModelUtilities
-SOURCEDIR7=../src/Model/Connection
-SOURCEDIR8=../src/Model/GroundWaterTransport
-SOURCEDIR9=../src/Model/GroundWaterFlow
-SOURCEDIR10=../src/Distributed
-SOURCEDIR11=../src/Solution
-SOURCEDIR12=../src/Solution/PETSc
-SOURCEDIR13=../src/Solution/LinearMethods
-SOURCEDIR14=../src/Solution/ParticleTracker
-SOURCEDIR15=../src/Timing
-SOURCEDIR16=../src/Utilities
-SOURCEDIR17=../src/Utilities/TimeSeries
-SOURCEDIR18=../src/Utilities/Libraries
-SOURCEDIR19=../src/Utilities/Libraries/rcm
-SOURCEDIR20=../src/Utilities/Libraries/sparsekit
-SOURCEDIR21=../src/Utilities/Libraries/sparskit2
-SOURCEDIR22=../src/Utilities/Libraries/blas
-SOURCEDIR23=../src/Utilities/Libraries/daglib
-SOURCEDIR24=../src/Utilities/Idm
-SOURCEDIR25=../src/Utilities/Idm/selector
-SOURCEDIR26=../src/Utilities/Idm/mf6blockfile
-SOURCEDIR27=../src/Utilities/Matrix
-SOURCEDIR28=../src/Utilities/Vector
-SOURCEDIR29=../src/Utilities/Observation
-SOURCEDIR30=../src/Utilities/OutputControl
-SOURCEDIR31=../src/Utilities/Memory
-SOURCEDIR32=../src/Utilities/ArrayRead
+SOURCEDIR3=../src/Distributed
+SOURCEDIR4=../src/Solution
+SOURCEDIR5=../src/Solution/LinearMethods
+SOURCEDIR6=../src/Solution/ParticleTracker
+SOURCEDIR7=../src/Solution/PETSc
+SOURCEDIR8=../src/Timing
+SOURCEDIR9=../src/Utilities
+SOURCEDIR10=../src/Utilities/Idm
+SOURCEDIR11=../src/Utilities/Idm/selector
+SOURCEDIR12=../src/Utilities/Idm/mf6blockfile
+SOURCEDIR13=../src/Utilities/TimeSeries
+SOURCEDIR14=../src/Utilities/Memory
+SOURCEDIR15=../src/Utilities/OutputControl
+SOURCEDIR16=../src/Utilities/ArrayRead
+SOURCEDIR17=../src/Utilities/Libraries
+SOURCEDIR18=../src/Utilities/Libraries/rcm
+SOURCEDIR19=../src/Utilities/Libraries/blas
+SOURCEDIR20=../src/Utilities/Libraries/sparskit2
+SOURCEDIR21=../src/Utilities/Libraries/daglib
+SOURCEDIR22=../src/Utilities/Libraries/sparsekit
+SOURCEDIR23=../src/Utilities/Vector
+SOURCEDIR24=../src/Utilities/Matrix
+SOURCEDIR25=../src/Utilities/Observation
+SOURCEDIR26=../src/Model
+SOURCEDIR27=../src/Model/Connection
+SOURCEDIR28=../src/Model/ParticleTracking
+SOURCEDIR29=../src/Model/GroundWaterTransport
+SOURCEDIR30=../src/Model/ModelUtilities
+SOURCEDIR31=../src/Model/GroundWaterFlow
+SOURCEDIR32=../src/Model/Geometry
 
 VPATH = \
 ${SOURCEDIR1} \
@@ -155,6 +155,7 @@ $(OBJDIR)/SimStages.o \
 $(OBJDIR)/NumericalModel.o \
 $(OBJDIR)/simnamidm.o \
 $(OBJDIR)/prt1idm.o \
+$(OBJDIR)/prt1mip1idm.o \
 $(OBJDIR)/prt1disv1idm.o \
 $(OBJDIR)/prt1dis1idm.o \
 $(OBJDIR)/gwt1idm.o \

--- a/msvs/mf6core.vfproj
+++ b/msvs/mf6core.vfproj
@@ -220,7 +220,9 @@
 		<File RelativePath="..\src\Model\ParticleTracking\prt1oc1.f90"/>
 		<File RelativePath="..\src\Model\ParticleTracking\prt1prp1.f90"/>
 		<File RelativePath="..\src\Model\ParticleTracking\prt1dis1idm.f90"/>
-		<File RelativePath="..\src\Model\ParticleTracking\prt1disv1idm.f90"/></Filter>
+		<File RelativePath="..\src\Model\ParticleTracking\prt1disv1idm.f90"/>
+		<File RelativePath="..\src\Model\ParticleTracking\prt1mip1idm.f90"/>
+		</Filter>
 		<Filter Name="Solution">
 		<Filter Name="LinearMethods">
 		<File RelativePath="..\src\Solution\LinearMethods\ims8base.f90"/>

--- a/src/Model/GroundWaterFlow/gwf3npf8.f90
+++ b/src/Model/GroundWaterFlow/gwf3npf8.f90
@@ -1080,19 +1080,13 @@ contains
     return
   end subroutine npf_print_model_flows
 
+  !> @brief Deallocate variables
   subroutine npf_da(this)
-! ******************************************************************************
-! npf_da -- Deallocate variables
-! ******************************************************************************
-!
-!    SPECIFICATIONS:
-! ------------------------------------------------------------------------------
     ! -- modules
     use MemoryManagerExtModule, only: memorylist_remove
     use SimVariablesModule, only: idm_context
     ! -- dummy
     class(GwfNpftype) :: this
-! ------------------------------------------------------------------------------
     !
     ! -- Deallocate input memory
     call memorylist_remove(this%name_model, 'NPF', idm_context)

--- a/src/Model/ParticleTracking/prt1.f90
+++ b/src/Model/ParticleTracking/prt1.f90
@@ -1612,7 +1612,7 @@ contains
     integer(I4B), dimension(:), allocatable :: bndpkgs
     integer(I4B) :: n
     integer(I4B) :: indis = 0 ! DIS enabled flag
-    ! character(len=LENMEMPATH) :: mempathdsp = ''
+    character(len=LENMEMPATH) :: mempathmip = ''
     !
     ! -- set input memory paths, input/model and input/model/namfile
     model_mempath = create_mem_path(component=this%name, context=idm_context)
@@ -1645,7 +1645,8 @@ contains
         ! case ('PIN6')
         !   this%inpin = inunit
       case ('MIP6')
-        this%inmip = inunit
+        this%inmip = 1
+        mempathmip = mempath
       case ('FMI6')
         this%infmi = inunit
         ! case ('MVT6')
@@ -1680,7 +1681,7 @@ contains
     !
     ! -- Create packages that are tied directly to model
     ! call pin_cr(this%pin, this%name, this%inpin, this%iout, this%dis)
-    call mip_cr(this%mip, this%name, this%inmip, this%iout, this%dis)
+    call mip_cr(this%mip, this%name, mempathmip, this%inmip, this%iout, this%dis)
     call prtfmi_cr(this%fmi, this%name, this%infmi, this%iout)
     ! call mst_cr(this%mst, this%name, this%inmst, this%iout, this%fmi)
     ! call adv_cr(this%adv, this%name, this%inadv, this%iout, this%fmi)

--- a/src/Model/ParticleTracking/prt1mip1idm.f90
+++ b/src/Model/ParticleTracking/prt1mip1idm.f90
@@ -1,0 +1,112 @@
+! ** Do Not Modify! MODFLOW 6 system generated file. **
+module PrtMipInputModule
+  use InputDefinitionModule, only: InputParamDefinitionType, &
+                                   InputBlockDefinitionType
+  private
+  public prt_mip_param_definitions
+  public prt_mip_aggregate_definitions
+  public prt_mip_block_definitions
+  public PrtMipParamFoundType
+  public prt_mip_multi_package
+
+  type PrtMipParamFoundType
+    logical :: porosity = .false.
+    logical :: retfactor = .false.
+    logical :: izone = .false.
+  end type PrtMipParamFoundType
+
+  logical :: prt_mip_multi_package = .false.
+
+  type(InputParamDefinitionType), parameter :: &
+    prtmip_porosity = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'MIP', & ! subcomponent
+    'GRIDDATA', & ! block
+    'POROSITY', & ! tag name
+    'POROSITY', & ! fortran variable
+    'DOUBLE1D', & ! type
+    'NODES', & ! shape
+    .true., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .true. & ! layered
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtmip_retfactor = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'MIP', & ! subcomponent
+    'GRIDDATA', & ! block
+    'RETFACTOR', & ! tag name
+    'RETFACTOR', & ! fortran variable
+    'DOUBLE1D', & ! type
+    'NODES', & ! shape
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .true. & ! layered
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prtmip_izone = InputParamDefinitionType &
+    ( &
+    'PRT', & ! component
+    'MIP', & ! subcomponent
+    'GRIDDATA', & ! block
+    'IZONE', & ! tag name
+    'IZONE', & ! fortran variable
+    'INTEGER1D', & ! type
+    'NODES', & ! shape
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .true. & ! layered
+    )
+
+  type(InputParamDefinitionType), parameter :: &
+    prt_mip_param_definitions(*) = &
+    [ &
+    prtmip_porosity, &
+    prtmip_retfactor, &
+    prtmip_izone &
+    ]
+
+  type(InputParamDefinitionType), parameter :: &
+    prt_mip_aggregate_definitions(*) = &
+    [ &
+    InputParamDefinitionType &
+    ( &
+    '', & ! component
+    '', & ! subcomponent
+    '', & ! block
+    '', & ! tag name
+    '', & ! fortran variable
+    '', & ! type
+    '', & ! shape
+    .false., & ! required
+    .false., & ! multi-record
+    .false., & ! preserve case
+    .false. & ! layered
+    ) &
+    ]
+
+  type(InputBlockDefinitionType), parameter :: &
+    prt_mip_block_definitions(*) = &
+    [ &
+    InputBlockDefinitionType( &
+    'OPTIONS', & ! blockname
+    .false., & ! required
+    .false., & ! aggregate
+    .false. & ! block_variable
+    ), &
+    InputBlockDefinitionType( &
+    'GRIDDATA', & ! blockname
+    .true., & ! required
+    .false., & ! aggregate
+    .false. & ! block_variable
+    ) &
+    ]
+
+end module PrtMipInputModule

--- a/src/Utilities/Idm/selector/IdmPrtDfnSelector.f90
+++ b/src/Utilities/Idm/selector/IdmPrtDfnSelector.f90
@@ -16,6 +16,10 @@ module IdmPrtDfnSelectorModule
                                prt_nam_aggregate_definitions, &
                                prt_nam_block_definitions, &
                                prt_nam_multi_package
+  use PrtMipInputModule, only: prt_mip_param_definitions, &
+                               prt_mip_aggregate_definitions, &
+                               prt_mip_block_definitions, &
+                               prt_mip_multi_package
 
   implicit none
   private
@@ -50,6 +54,8 @@ contains
       call set_param_pointer(input_definition, prt_disv_param_definitions)
     case ('NAM')
       call set_param_pointer(input_definition, prt_nam_param_definitions)
+    case ('MIP')
+      call set_param_pointer(input_definition, prt_mip_param_definitions)
     case default
     end select
     return
@@ -66,6 +72,8 @@ contains
       call set_param_pointer(input_definition, prt_disv_aggregate_definitions)
     case ('NAM')
       call set_param_pointer(input_definition, prt_nam_aggregate_definitions)
+    case ('MIP')
+      call set_param_pointer(input_definition, prt_mip_aggregate_definitions)
     case default
     end select
     return
@@ -82,6 +90,8 @@ contains
       call set_block_pointer(input_definition, prt_disv_block_definitions)
     case ('NAM')
       call set_block_pointer(input_definition, prt_nam_block_definitions)
+    case ('MIP')
+      call set_block_pointer(input_definition, prt_mip_block_definitions)
     case default
     end select
     return
@@ -97,6 +107,8 @@ contains
       multi_package = prt_disv_multi_package
     case ('NAM')
       multi_package = prt_nam_multi_package
+    case ('MIP')
+      multi_package = prt_mip_multi_package
     case default
       call store_error('Idm selector subcomponent not found; '//&
                        &'component="PRT"'//&
@@ -115,6 +127,8 @@ contains
     case ('DISV')
       integrated = .true.
     case ('NAM')
+      integrated = .true.
+    case ('MIP')
       integrated = .true.
     case default
     end select

--- a/src/meson.build
+++ b/src/meson.build
@@ -114,6 +114,7 @@ modflow_sources = files(
     'Model' / 'ParticleTracking' / 'prt1dis1idm.f90',
     # 'Model' / 'ParticleTracking' / 'prt1disu1idm.f90',
     'Model' / 'ParticleTracking' / 'prt1disv1idm.f90',
+    'Model' / 'ParticleTracking' / 'prt1mip1idm.f90',
     'Model' / 'ModelUtilities' / 'BoundaryPackage.f90',
     'Model' / 'ModelUtilities' / 'Connections.f90',
     'Model' / 'ModelUtilities' / 'DiscretizationBase.f90',

--- a/utils/idmloader/scripts/dfn2f90.py
+++ b/utils/idmloader/scripts/dfn2f90.py
@@ -889,6 +889,10 @@ if __name__ == "__main__":
             Path("../../../doc/mf6io/mf6ivar/dfn", "sim-nam.dfn"),
             Path("../../../src", "simnamidm.f90"),
         ],
+        [
+            Path("../../../doc/mf6io/mf6ivar/dfn", "prt-mip.dfn"),
+            Path("../../../src/Model/ParticleTracking", "prt1mip1idm.f90"),
+        ]
     ]
 
     dfn_d = {}


### PR DESCRIPTION
Simulation-/model-level integration already completed: 

- DIS
- DISV
- NAM

This PR integrates the MIP package with IDM.

Remaining PRT packages to integrate include:

- FMI
- OC
- PRP

PRP will need to wait until IDM supports boundary packages.

Before tackling FMI, it may be worth deciding whether to keep the factored-out FlowModelInterface and use it for GWT as well, or remove it and have PRT FMI extend NumericalPackage directly as GWT FMI does.

OC has not been integrated for GWF or GWT yet, so will be an exploratory exercise, but @mjreno suggests it should be straightforward. Will attempt in separate changeset.