### PR TITLE
feat(PRP): support particle (bound)names

### DIFF
--- a/autotest/prt_test_utils.py
+++ b/autotest/prt_test_utils.py
@@ -155,3 +155,14 @@ def get_ireason_code(output_event):
         else 4 if output_event == "WEAKSINK"
         else -1 # default
     )
+
+
+def all_equal(col, val):
+    a = col.to_numpy()
+    return a[0] == val and (a[0] == a).all()
+
+
+def has_default_boundnames(data):
+    name = [int(n.rpartition("0")[2]) for n in data["name"].to_numpy()]
+    irpt = data["irpt"].to_numpy()
+    return np.array_equal(name, irpt)

--- a/autotest/test_prt_fmi02.py
+++ b/autotest/test_prt_fmi02.py
@@ -321,7 +321,6 @@ def test_prt_fmi02(idx, name, function_tmpdir, targets):
 
     # write mf6 simulation input files
     gwfsim.write_simulation()
-
     # run mf6 gwf simulation
     success, _ = gwfsim.run_simulation()
     assert success

--- a/src/Model/ModelUtilities/TrackData.f90
+++ b/src/Model/ModelUtilities/TrackData.f90
@@ -55,11 +55,11 @@ module TrackModule
 
   character(len=*), parameter, public :: TRACKHEADERS = &
                 'kper,kstp,imdl,iprp,irpt,ilay,icell,izone,istatus,ireason,&
-                &trelease,t,x,y,z'
+                &trelease,t,x,y,z,name'
 
   character(len=*), parameter, public :: TRACKTYPES = &
                              '<i4,<i4,<i4,<i4,<i4,<i4,<i4,<i4,<i4,<i4,&
-                             &<f8,<f8,<f8,<f8,<f8'
+                             &<f8,<f8,<f8,<f8,<f8,|S40'
 
   ! Notes
   ! -----
@@ -205,7 +205,8 @@ contains
         particle%ttrack, &
         xmodel, &
         ymodel, &
-        zmodel
+        zmodel, &
+        trim(adjustl(particle%name))
     else
       write (iun) &
         kper, &
@@ -222,7 +223,8 @@ contains
         particle%ttrack, &
         xmodel, &
         ymodel, &
-        zmodel
+        zmodel, &
+        particle%name
     end if
   end subroutine
 
@@ -254,7 +256,7 @@ contains
     !    deeper before advancing the particle and unwinding.
     if (present(level) .and. level .ne. 3) return
 
-    ! save binary file(s) if enabled
+    ! save model-level file(s) if enabled
     if (this%trackfile%iun > 0) &
       call save_internal(this%trackfile%iun, particle, &
                          kper, kstp, reason, level, csv=.false.)
@@ -273,6 +275,11 @@ contains
     end if
   end subroutine save_record
 
+  !> @brief Set the event to be reported.
+  !!
+  !! itrackevent -1 corresponds to TRACKEVENT ALL
+  !! and so on. If itrackevent >= 0, the selected
+  !! event type will be saved and others omitted.
   subroutine set_track_event(this, itrackevent)
     class(TrackControlType) :: this
     integer(I4B), intent(in) :: itrackevent

--- a/src/Model/ParticleTracking/prt1.f90
+++ b/src/Model/ParticleTracking/prt1.f90
@@ -21,7 +21,7 @@ module PrtModule
   use MethodDisModule, only: MethodDisType
   use MethodDisvModule, only: MethodDisvType
   ! use MethodDisuModule, only: MethodDisuType
-  use ParticleModule ! kluge
+  use ParticleModule
   use MethodModule
   use GlobalDataModule
   use TrackModule, only: TrackControlType, TrackFileType

--- a/src/Model/ParticleTracking/prt1prp1.f90
+++ b/src/Model/ParticleTracking/prt1prp1.f90
@@ -338,6 +338,7 @@ contains
     integer(I4B) :: nps, np
     real(DP) :: trelease, tstop
     logical(LGP) :: isRelease
+    character(len=LENBOUNDNAME) :: bndName = ''
     !
     ! -- Reset particle mass released for time step
     do nps = 1, this%nreleasepts
@@ -421,6 +422,10 @@ contains
 
         ! -- Todo: check that location is within the specified cell
 
+        ! -- Set particle boundname
+        if (size(this%boundname) /= 0) &
+          bndName = this%boundname(nps)
+
         ! -- Add particle to particle list (todo: factor out a routine?)
         !    The routine should branch based on whether this is an exchange
         !    PRP or a normal PRP. If exchange PRP, particle identity info
@@ -438,6 +443,7 @@ contains
         this%partlist%istopweaksink(np) = this%istopweaksink
         this%partlist%istopzone(np) = this%istopzone
         this%partlist%irpt(np) = nps
+        this%partlist%name(np) = bndName
         this%partlist%icu = icu
         this%partlist%ilay = ilay
         this%partlist%izone = this%izone(ic)
@@ -825,7 +831,7 @@ contains
     class(PrtPrpType), intent(inout) :: this
     ! -- local
     character(len=LINELENGTH) :: cellid
-    character(len=LENBOUNDNAME) :: bndName !, bndNameTemp
+    character(len=LENBOUNDNAME) :: bndName, bndNameTemp
     character(len=9) :: cno
     logical :: isfound
     logical :: endOfBlock
@@ -893,18 +899,20 @@ contains
         y(n) = this%parser%GetDouble()
         z(n) = this%parser%GetDouble()
         !
-        ! -- set default bndName
+        ! -- set default boundname
         write (cno, '(i9.9)') n
         bndName = 'PRP'//cno
         !
-        ! ! -- todo read particle release point name from file
-        ! if (this%inamedbound /= 0) then
-        !   call this%parser%GetStringCaps(bndNameTemp)
-        !   if (bndNameTemp /= '') then
-        !     bndName = bndNameTemp
-        !   end if
-        ! end if
+        ! -- read boundnames from file, if provided
+        if (this%inamedbound /= 0) then
+          call this%parser%GetStringCaps(bndNameTemp)
+          if (bndNameTemp /= '') &
+            bndName = bndNameTemp
+        else
+          bndName = ''
+        end if
         !
+        ! -- store temp boundnames
         nametxt(n) = bndName
         !
       end do
@@ -950,6 +958,7 @@ contains
     deallocate (y)
     deallocate (z)
     deallocate (tstop)
+    deallocate (nametxt)
     deallocate (nboundchk)
     !
     ! -- return

--- a/src/Solution/ParticleTracker/Method.f90
+++ b/src/Solution/ParticleTracker/Method.f90
@@ -2,7 +2,7 @@ module MethodModule
 
   use KindModule, only: DP, I4B
   use GlobalDataModule
-  use ParticleModule ! kluge???
+  use ParticleModule
   use CellDefnModule, only: CellDefnType
   use TrackModule, only: TrackControlType
   implicit none
@@ -158,7 +158,6 @@ contains
     class(MethodType), intent(inout) :: this
     type(ParticleType), pointer, intent(inout) :: particle
     type(CellDefnType), pointer, intent(inout) :: celldefn
-
     particle%izone = celldefn%izone
 
     if (celldefn%izone .ne. 0) then

--- a/src/Solution/ParticleTracker/Particle.f90
+++ b/src/Solution/ParticleTracker/Particle.f90
@@ -1,7 +1,7 @@
 module ParticleModule
 
   use KindModule, only: DP, I4B, LGP
-  use ConstantsModule, only: DZERO, DONE, LENMEMPATH, LENCOMPONENTNAME
+  use ConstantsModule, only: DZERO, DONE, LENMEMPATH, LENBOUNDNAME
   use GlobalDataModule
   use UtilMiscModule, only: transform_coords, modify_transf
   implicit none
@@ -20,6 +20,7 @@ module ParticleModule
     integer(I4B), public :: iprp ! index of release package the particle originated in
     integer(I4B), public :: irpt ! index of release point in the particle release package the particle originated in
     integer(I4B), public :: ip ! index of particle in the particle list
+    character(len=LENBOUNDNAME), public :: name = '' ! optional particle label (need not be unique)
 
     ! stop criteria
     integer(I4B), public :: istopweaksink ! weak sink option: 0 = do not stop, 1 = stop
@@ -65,6 +66,7 @@ module ParticleModule
     integer(I4B), dimension(:), pointer, contiguous :: imdl ! index of model particle originated in
     integer(I4B), dimension(:), pointer, contiguous :: iprp ! index of release package the particle originated in
     integer(I4B), dimension(:), pointer, contiguous :: irpt ! index of release point in the particle release package the particle originated in
+    character(len=LENBOUNDNAME), dimension(:), pointer, contiguous :: name ! optional particle label (need not be unique)
 
     ! stopping criteria
     integer(I4B), dimension(:), pointer, contiguous :: istopweaksink ! weak sink option: 0 = do not stop, 1 = stop
@@ -128,6 +130,7 @@ contains
     call mem_allocate(this%imdl, np, 'PLIMDL', mempath)
     call mem_allocate(this%irpt, np, 'PLIRPT', mempath)
     call mem_allocate(this%iprp, np, 'PLIPRP', mempath)
+    call mem_allocate(this%name, LENBOUNDNAME, np, 'PLNAME', mempath)
     ! -- kluge todo: update mem_allocate to allow custom range of indices?
     !    e.g. here we want to allocate 0-4 for trackdomain levels, not 1-5
     allocate (this%iTrackingDomain(np, lmin:lmax))
@@ -159,6 +162,7 @@ contains
     call mem_deallocate(this%imdl, 'PLIMDL', mempath)
     call mem_deallocate(this%iprp, 'PLIPRP', mempath)
     call mem_deallocate(this%irpt, 'PLIRPT', mempath)
+    call mem_deallocate(this%name, 'PLNAME', mempath)
     deallocate (this%iTrackingDomain)
     deallocate (this%iTrackingDomainBoundary)
     call mem_deallocate(this%icu, 'PLICU', mempath)
@@ -191,6 +195,7 @@ contains
     call mem_reallocate(this%imdl, np, 'PLIMDL', mempath)
     call mem_reallocate(this%iprp, np, 'PLIPRP', mempath)
     call mem_reallocate(this%irpt, np, 'PLIRPT', mempath)
+    call mem_reallocate(this%name, LENBOUNDNAME, np, 'PLNAME', mempath)
     call mem_reallocate(this%icu, np, 'PLICU', mempath)
     call mem_reallocate(this%ilay, np, 'PLILAY', mempath)
     call mem_reallocate(this%izone, np, 'PLIZONE', mempath)
@@ -234,6 +239,7 @@ contains
     this%iprp = iprp
     this%irpt = partlist%irpt(ip) ! kluge note: necessary to reset this here?
     this%ip = ip
+    this%name = partlist%name(ip)
     this%istopweaksink = partlist%istopweaksink(ip)
     this%istopzone = partlist%istopzone(ip)
     this%iTrackingDomain(levelMin:levelMax) = &


### PR DESCRIPTION
Finish support for particle names (labels, really) via boundname option/mechanism in the particle release (PRP) package. This was supported for a default value previously, but not for user input.

Particle names need not be unique.

Particle names are padded to 40 characters (standard for boundnames) in binary output files and truncated in CSV output files.